### PR TITLE
brimcap load: index pcap

### DIFF
--- a/cli/rootflags.go
+++ b/cli/rootflags.go
@@ -4,27 +4,31 @@ import (
 	"errors"
 	"flag"
 	"os"
+
+	"github.com/brimdata/brimcap"
 )
 
 type RootFlags struct {
-	Root string
+	root string
+	Root brimcap.Root
 }
 
 func (f *RootFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Root, "root", "", "location of brimcap root (where indices are saved)")
+	fs.StringVar(&f.root, "root", "", "location of brimcap root (where indices are saved)")
 }
 
 func (f *RootFlags) Init() error {
-	if f.Root == "" {
+	if f.root == "" {
 		return errors.New("brimcap root (-root) must be specified")
 	}
 
-	info, err := os.Stat(f.Root)
+	info, err := os.Stat(f.root)
 	if err != nil {
 		return err
 	}
 	if !info.IsDir() {
 		return errors.New("brimcap root must be a directory")
 	}
+	f.Root = brimcap.Root(f.root)
 	return nil
 }

--- a/cli/rootflags.go
+++ b/cli/rootflags.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"os"
+)
+
+type RootFlags struct {
+	Root string
+}
+
+func (f *RootFlags) SetFlags(fs *flag.FlagSet) {
+	fs.StringVar(&f.Root, "root", "", "location of brimcap root (where indices are saved)")
+}
+
+func (f *RootFlags) Init() error {
+	if f.Root == "" {
+		return errors.New("brimcap root (-root) must be specified")
+	}
+
+	info, err := os.Stat(f.Root)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("brimcap root must be a directory")
+	}
+	return nil
+}

--- a/cmd/brimcap/analyze/command.go
+++ b/cmd/brimcap/analyze/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/brimcap/cmd/brimcap/root"
 	"github.com/brimdata/zed/cli/outputflags"
 	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/signalctx"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zng/resolver"
@@ -68,14 +69,14 @@ func (c *Command) Exec(args []string) (err error) {
 	}
 	defer pcapfile.Close()
 
-	display := analyzecli.NewDisplay(c.JSON, pcapsize)
+	display := analyzecli.NewDisplay(c.JSON)
 	zctx := resolver.NewContext()
 	analyzer := analyzer.CombinerWithContext(ctx, zctx, pcapfile, c.analyzeflags.Configs...)
 
 	// If not emitting to stdio write stats to stderr.
 	if c.out.FileName() != "" {
-		display := analyzecli.NewDisplay(c.JSON, pcapsize)
-		display.Run(analyzer)
+		display := analyzecli.NewDisplay(c.JSON)
+		display.Run(analyzer, pcapsize, nano.Span{})
 		defer display.Close()
 	}
 

--- a/cmd/brimcap/index/command.go
+++ b/cmd/brimcap/index/command.go
@@ -71,15 +71,7 @@ func (c *Command) Exec(args []string) (err error) {
 		defer f.Close()
 	}
 
-	warn := make(chan string)
-	var index pcap.Index
-	go func() {
-		index, err = pcap.CreateIndexWithWarnings(f, c.limit, warn)
-		close(warn)
-	}()
-	for s := range warn {
-		fmt.Fprintf(os.Stderr, "warning: %s\n", s)
-	}
+	index, err := pcap.CreateIndexWithWarnings(f, c.limit, c)
 	if err != nil {
 		return err
 	}
@@ -92,4 +84,9 @@ func (c *Command) Exec(args []string) (err error) {
 		return nil
 	}
 	return os.WriteFile(c.outputFile, b, 0644)
+}
+
+func (c *Command) Warn(msg string) error {
+	fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
+	return nil
 }

--- a/cmd/brimcap/load/command.go
+++ b/cmd/brimcap/load/command.go
@@ -90,8 +90,6 @@ func (c *Command) Exec(args []string) (err error) {
 	display := analyzecli.NewDisplay(c.JSON)
 	pcappath := args[0]
 	root := c.rootflags.Root
-
-	// write index pcap symlink to brimcap root
 	span, err := root.AddPcap(pcappath, c.limit, display)
 	if err != nil {
 		return fmt.Errorf("error writing brimcap root: %w", err)

--- a/pcap/index.go
+++ b/pcap/index.go
@@ -54,8 +54,8 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 	return CreateIndexWithWarnings(r, size, nil)
 }
 
-func CreateIndexWithWarnings(r io.Reader, size int, c chan<- string) (Index, error) {
-	reader, err := pcapio.NewReaderWithWarnings(r, c)
+func CreateIndexWithWarnings(r io.Reader, size int, w pcapio.Warner) (Index, error) {
+	reader, err := pcapio.NewReaderWithWarnings(r, w)
 	if err != nil {
 		return nil, err
 	}

--- a/pcap/pcapio/error.go
+++ b/pcap/pcapio/error.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 )
 
+type Warner interface {
+	Warn(msg string) error
+}
+
 type ErrInvalidPcap struct {
 	err error
 }

--- a/pcap/pcapio/ngread.go
+++ b/pcap/pcapio/ngread.go
@@ -31,7 +31,7 @@ type NgReader struct {
 	first     []byte
 	bigEndian bool
 	offset    uint64
-	warningCh chan<- string
+	warner    Warner
 }
 
 // NewNgReader initializes a new writer, reads the first section header,
@@ -67,13 +67,13 @@ func NewNgReader(r io.Reader) (*NgReader, error) {
 	return ret, nil
 }
 
-func (r *NgReader) SetWarningChan(c chan<- string) {
-	r.warningCh = c
+func (r *NgReader) SetWarningHandler(warner Warner) {
+	r.warner = warner
 }
 
 func (r *NgReader) warn(format string, a ...interface{}) {
-	if c := r.warningCh; c != nil {
-		c <- fmt.Sprintf(format, a...)
+	if r.warner != nil {
+		r.warner.Warn(fmt.Sprintf(format, a...))
 	}
 }
 

--- a/pcap/pcapio/reader.go
+++ b/pcap/pcapio/reader.go
@@ -41,7 +41,7 @@ func NewReader(r io.Reader) (Reader, error) {
 // and arranges for warning messages to be sent over the given channel.  Different
 // pcap implementations can have out-of-spec peculiarities that can be tolerated
 // so we send warnings and try to keep going.
-func NewReaderWithWarnings(r io.Reader, warningCh chan<- string) (Reader, error) {
+func NewReaderWithWarnings(r io.Reader, warner Warner) (Reader, error) {
 	record := recorder.NewRecorder(r)
 	track := recorder.NewTrack(record)
 	_, err1 := NewPcapReader(track)
@@ -52,7 +52,7 @@ func NewReaderWithWarnings(r io.Reader, warningCh chan<- string) (Reader, error)
 	_, err2 := NewNgReader(track)
 	if err2 == nil {
 		r, err := NewNgReader(record)
-		r.SetWarningChan(warningCh)
+		r.SetWarningHandler(warner)
 		return r, err
 	}
 	var pcaperr, ngerr *ErrInvalidPcap

--- a/root.go
+++ b/root.go
@@ -1,0 +1,66 @@
+package brimcap
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/brimdata/brimcap/pcap"
+	"github.com/brimdata/zed/pkg/fs"
+	"github.com/brimdata/zed/pkg/nano"
+	"github.com/brimdata/zed/zbuf"
+)
+
+type Root string
+
+// AddPcap adds the pcap path to the BRIMCAP_ROOT, meaning a symlink for the pcap is
+// added to the root directory along with an index of the pcap.
+func (r Root) AddPcap(path string, limit int, warner zbuf.Warner) (nano.Span, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nano.Span{}, nil
+	}
+	defer f.Close()
+
+	index, err := pcap.CreateIndexWithWarnings(f, limit, warner)
+	if err != nil {
+		return nano.Span{}, err
+	}
+
+	// symlink path to root
+	if err := os.Symlink(path, r.SymlinkPath(path)); err != nil {
+		return nano.Span{}, err
+	}
+
+	// create pcap index
+	if err = fs.MarshalJSONFile(index, r.IndexPath(path), 0644); err != nil {
+		r.DeletePcap(path)
+		return nano.Span{}, err
+	}
+
+	return index.Span(), nil
+}
+
+func (r Root) SymlinkPath(path string) string {
+	return r.join(filepath.Base(path))
+}
+
+func (r Root) IndexPath(path string) string {
+	return r.join(filepath.Base(path) + ".idx")
+}
+
+// DeletePcap removes all files associated with the pcap path (if they exist).
+func (r Root) DeletePcap(path string) error {
+	err1 := os.Remove(r.SymlinkPath(path))
+	err2 := os.Remove(r.IndexPath(path))
+	if err1 != nil && !os.IsNotExist(err1) {
+		return err1
+	}
+	if os.IsNotExist(err2) {
+		err2 = nil
+	}
+	return err2
+}
+
+func (r Root) join(els ...string) string {
+	return filepath.Join(append([]string{string(r)}, els...)...)
+}


### PR DESCRIPTION
Brimcap load should create an index and a symlink to the processed pcap,
written the BRIMCAP_ROOT.

Closes #6 