### PR TITLE
Add brimcap launch command

### DIFF
--- a/cli/pcapsearchflags.go
+++ b/cli/pcapsearchflags.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/brimdata/brimcap"
+	"github.com/brimdata/zed/pkg/nano"
+	"go.uber.org/multierr"
+)
+
+type PcapSearchFlags struct {
+	Search brimcap.Search
+
+	ts       *tsArg
+	duration time.Duration
+	proto    string
+	srcip    ipArg
+	srcport  portArg
+	dstip    ipArg
+	dstport  portArg
+}
+
+func (f *PcapSearchFlags) SetFlags(fs *flag.FlagSet) {
+	f.ts = new(tsArg)
+	fs.Var(f.ts, "ts", "the starting time stamp of the connection")
+	fs.DurationVar(&f.duration, "duration", 0, "the duration of the connection")
+	fs.StringVar(&f.proto, "proto", "", "protocol of the connection (either tcp, udp or icmp)")
+	fs.Var(&f.srcip, "src.ip", "ip address of the connection source")
+	fs.Var(&f.srcport, "src.port", "port of the connection source")
+	fs.Var(&f.dstip, "dst.ip", "ip address of the connection destination")
+	fs.Var(&f.dstport, "dst.port", "port of the connection destination")
+}
+
+func (f *PcapSearchFlags) Init() error {
+	var merr error
+	if f.ts == nil {
+		merr = multierr.Append(merr, errFlagRequired("-start"))
+	}
+	if f.srcip == nil {
+		merr = multierr.Append(merr, errFlagRequired("-src.ip"))
+	}
+	if f.dstip == nil {
+		merr = multierr.Append(merr, errFlagRequired("-dst.ip"))
+	}
+	switch f.proto {
+	case "tcp", "udp", "icmp":
+	case "":
+		merr = multierr.Append(merr, errFlagRequired("-proto"))
+	default:
+		merr = multierr.Append(merr, fmt.Errorf("unsupported value for %q: %q", "-proto", f.proto))
+	}
+	if merr != nil {
+		return merr
+	}
+	f.Search = brimcap.Search{
+		Span:    nano.Span{Ts: nano.Ts(*f.ts), Dur: nano.Duration(f.duration)},
+		Proto:   f.proto,
+		SrcIP:   net.IP(f.srcip),
+		SrcPort: uint16(f.srcport),
+		DstIP:   net.IP(f.dstip),
+		DstPort: uint16(f.dstport),
+	}
+	return nil
+}
+
+func errFlagRequired(flag string) error {
+	return fmt.Errorf("%q required", flag)
+}
+
+type tsArg nano.Ts
+
+func (t *tsArg) String() string {
+	if t == nil {
+		return ""
+	}
+	return nano.Ts(*t).String()
+}
+
+func (t *tsArg) Set(s string) error {
+	out, err := nano.ParseRFC3339Nano([]byte(s))
+	*t = tsArg(out)
+	return err
+}
+
+type ipArg net.IP
+
+func (i ipArg) String() string {
+	if i == nil {
+		return ""
+	}
+	return net.IP(i).String()
+}
+
+func (i *ipArg) Set(s string) error {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return fmt.Errorf("invalid IP value: %q", s)
+	}
+	*i = ipArg(ip)
+	return nil
+}
+
+type portArg uint16
+
+func (i portArg) String() string {
+	if i == 0 {
+		return ""
+	}
+	return strconv.FormatUint(uint64(i), 10)
+}
+
+func (i *portArg) Set(s string) (err error) {
+	val, err := strconv.ParseUint(s, 10, 16)
+	*i = portArg(val)
+	return err
+}

--- a/cli/rootflags.go
+++ b/cli/rootflags.go
@@ -9,8 +9,10 @@ import (
 )
 
 type RootFlags struct {
-	root string
-	Root brimcap.Root
+	root     string
+	Optional bool
+	IsSet    bool
+	Root     brimcap.Root
 }
 
 func (f *RootFlags) SetFlags(fs *flag.FlagSet) {
@@ -19,8 +21,12 @@ func (f *RootFlags) SetFlags(fs *flag.FlagSet) {
 
 func (f *RootFlags) Init() error {
 	if f.root == "" {
-		return errors.New("brimcap root (-root) must be specified")
+		if !f.Optional {
+			return errors.New("brimcap root (-root) must be specified")
+		}
+		return nil
 	}
+	f.IsSet = true
 
 	info, err := os.Stat(f.root)
 	if err != nil {

--- a/cmd/brimcap/index/command.go
+++ b/cmd/brimcap/index/command.go
@@ -2,10 +2,12 @@ package index
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 
+	"github.com/brimdata/brimcap/cli"
 	"github.com/brimdata/brimcap/cmd/brimcap/root"
 	"github.com/brimdata/brimcap/pcap"
 	"github.com/brimdata/zed/pkg/charm"
@@ -43,6 +45,7 @@ func init() {
 type Command struct {
 	*root.Command
 	limit      int
+	rootflags  cli.RootFlags
 	inputFile  string
 	outputFile string
 }
@@ -50,15 +53,29 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	c.Command.Child = c
+	c.rootflags.Optional = true
+	c.rootflags.SetFlags(f)
 	f.StringVar(&c.inputFile, "r", "-", "input file to read from or stdin if -")
 	f.StringVar(&c.outputFile, "x", "-", "name of output file for the index or - for stdout")
 	f.IntVar(&c.limit, "n", 10000, "limit on index size")
 	return c, nil
 }
 
+func (c *Command) Init() error {
+	if c.rootflags.IsSet {
+		if c.outputFile != "-" {
+			return errors.New("-root and -x cannot both be set")
+		}
+		if c.inputFile == "-" {
+			return errors.New("input cannot be standard in if writing to BRIMCAP_ROOT")
+		}
+	}
+	return nil
+}
+
 func (c *Command) Exec(args []string) (err error) {
 	defer c.Cleanup()
-	if err := c.Init(); err != nil {
+	if err := c.Command.Init(&c.rootflags); err != nil {
 		return err
 	}
 
@@ -75,10 +92,16 @@ func (c *Command) Exec(args []string) (err error) {
 	if err != nil {
 		return err
 	}
+
+	if c.rootflags.IsSet {
+		return c.rootflags.Root.AddPcapWithIndex(c.inputFile, index)
+	}
+
 	b, err := json.Marshal(index)
 	if err != nil {
 		return err
 	}
+
 	if c.outputFile == "-" {
 		fmt.Println(string(b))
 		return nil
@@ -86,6 +109,7 @@ func (c *Command) Exec(args []string) (err error) {
 	return os.WriteFile(c.outputFile, b, 0644)
 }
 
+// XXX this should log to json in root command -json flag is set
 func (c *Command) Warn(msg string) error {
 	fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
 	return nil

--- a/cmd/brimcap/index/command.go
+++ b/cmd/brimcap/index/command.go
@@ -67,7 +67,7 @@ func (c *Command) Init() error {
 			return errors.New("-root and -x cannot both be set")
 		}
 		if c.inputFile == "-" {
-			return errors.New("input cannot be standard in if writing to BRIMCAP_ROOT")
+			return errors.New("input cannot be stdin if writing to BRIMCAP_ROOT")
 		}
 	}
 	return nil

--- a/cmd/brimcap/launch/command.go
+++ b/cmd/brimcap/launch/command.go
@@ -53,7 +53,9 @@ func (c *Command) Exec(args []string) (err error) {
 		return err
 	}
 
-	err = c.rootflags.Root.Search(context.TODO(), c.searchflags.Search, f)
+	ctx, cancel := signal.NotifyContext(context.Baackground(), os.Interrupt)
+	defer cancel()
+	err = c.rootflags.Root.Search(ctx, c.searchflags.Search, f)
 	f.Close()
 	if err != nil {
 		return err

--- a/cmd/brimcap/launch/command.go
+++ b/cmd/brimcap/launch/command.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"os/exec"
+	"os/signal"
 
 	"github.com/brimdata/brimcap/cli"
 	"github.com/brimdata/brimcap/cmd/brimcap/root"
@@ -53,7 +54,7 @@ func (c *Command) Exec(args []string) (err error) {
 		return err
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Baackground(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	err = c.rootflags.Root.Search(ctx, c.searchflags.Search, f)
 	f.Close()

--- a/cmd/brimcap/launch/command.go
+++ b/cmd/brimcap/launch/command.go
@@ -1,0 +1,63 @@
+package launch
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/exec"
+
+	"github.com/brimdata/brimcap/cli"
+	"github.com/brimdata/brimcap/cmd/brimcap/root"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var Launch = &charm.Spec{
+	Name:  "launch",
+	Usage: "launch [options]",
+	Short: "",
+	Long:  ``,
+	New:   New,
+}
+
+func init() {
+	root.Brimcap.Add(Launch)
+}
+
+type Command struct {
+	*root.Command
+	rootflags   cli.RootFlags
+	searchflags cli.PcapSearchFlags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	c.Command.Child = c
+	c.rootflags.SetFlags(f)
+	c.searchflags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Init() error {
+	_, err := exec.LookPath("wireshark")
+	return err
+}
+
+func (c *Command) Exec(args []string) (err error) {
+	if err := c.Command.Init(&c.rootflags, &c.searchflags, c); err != nil {
+		return err
+	}
+	defer c.Cleanup()
+
+	f, err := os.CreateTemp("", "brimcap-launch-")
+	if err != nil {
+		return err
+	}
+
+	err = c.rootflags.Root.Search(context.TODO(), c.searchflags.Search, f)
+	f.Close()
+	if err != nil {
+		return err
+	}
+
+	return exec.Command("wireshark", "-r", f.Name()).Start()
+}

--- a/cmd/brimcap/main.go
+++ b/cmd/brimcap/main.go
@@ -7,8 +7,10 @@ import (
 	_ "github.com/brimdata/brimcap/cmd/brimcap/cut"
 	_ "github.com/brimdata/brimcap/cmd/brimcap/index"
 	_ "github.com/brimdata/brimcap/cmd/brimcap/info"
+	_ "github.com/brimdata/brimcap/cmd/brimcap/launch"
 	_ "github.com/brimdata/brimcap/cmd/brimcap/load"
 	"github.com/brimdata/brimcap/cmd/brimcap/root"
+	_ "github.com/brimdata/brimcap/cmd/brimcap/search"
 	_ "github.com/brimdata/brimcap/cmd/brimcap/slice"
 	_ "github.com/brimdata/brimcap/cmd/brimcap/ts"
 )

--- a/cmd/brimcap/search/command.go
+++ b/cmd/brimcap/search/command.go
@@ -1,0 +1,63 @@
+package search
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/brimdata/brimcap/cli"
+	"github.com/brimdata/brimcap/cmd/brimcap/root"
+	"github.com/brimdata/zed/pkg/charm"
+)
+
+var Search = &charm.Spec{
+	Name:  "search",
+	Usage: "search [options]",
+	Short: "",
+	Long:  ``,
+	New:   New,
+}
+
+func init() {
+	root.Brimcap.Add(Search)
+}
+
+type Command struct {
+	*root.Command
+	outfile     string
+	rootflags   cli.RootFlags
+	searchflags cli.PcapSearchFlags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	c.Command.Child = c
+	f.StringVar(&c.outfile, "w", "-", "file to write to or stdout if -")
+	c.rootflags.SetFlags(f)
+	c.searchflags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Exec(args []string) (err error) {
+	if err := c.Command.Init(&c.rootflags, &c.searchflags); err != nil {
+		return err
+	}
+	defer c.Cleanup()
+
+	out := os.Stdout
+	if c.outfile != "-" {
+		out, err = os.Create(c.outfile)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = c.rootflags.Root.Search(context.TODO(), c.searchflags.Search, out)
+	if c.outfile != "-" {
+		out.Close()
+		if err != nil {
+			os.Remove(c.outfile)
+		}
+	}
+	return err
+}

--- a/cmd/brimcap/search/command.go
+++ b/cmd/brimcap/search/command.go
@@ -52,7 +52,9 @@ func (c *Command) Exec(args []string) (err error) {
 		}
 	}
 
-	err = c.rootflags.Root.Search(context.TODO(), c.searchflags.Search, out)
+	ctx, cancel := signal.NotifyContext(context.Baackground(), os.Interrupt)
+	defer cancel()
+	err = c.rootflags.Root.Search(ctx, c.searchflags.Search, out)
 	if c.outfile != "-" {
 		out.Close()
 		if err != nil {

--- a/cmd/brimcap/search/command.go
+++ b/cmd/brimcap/search/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"os"
+	"os/signal"
 
 	"github.com/brimdata/brimcap/cli"
 	"github.com/brimdata/brimcap/cmd/brimcap/root"
@@ -52,7 +53,7 @@ func (c *Command) Exec(args []string) (err error) {
 		}
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Baackground(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	err = c.rootflags.Root.Search(ctx, c.searchflags.Search, out)
 	if c.outfile != "-" {

--- a/cmd/brimcap/slice/command.go
+++ b/cmd/brimcap/slice/command.go
@@ -157,7 +157,7 @@ func (c *Command) Exec(args []string) error {
 		}()
 		out = w
 	}
-	var search *pcap.Search
+	var search pcap.Search
 	if filter {
 		switch c.proto {
 		case "tcp":

--- a/cmd/brimcap/ts/command.go
+++ b/cmd/brimcap/ts/command.go
@@ -1,4 +1,4 @@
-package slice
+package ts
 
 import (
 	"errors"

--- a/cmd/brimcap/ztests/search-duplicate.yaml
+++ b/cmd/brimcap/ztests/search-duplicate.yaml
@@ -1,0 +1,37 @@
+script: |
+  mkdir root
+  brimcap index -root root -r non-overlap1.pcapng
+  brimcap index -root root -r non-overlap2.pcapng
+
+  brimcap search -root root \
+    -w result.pcap \
+    -ts 2020-03-09T15:42:03.826851Z \
+    -duration 428us \
+    -proto tcp \
+    -src.ip 192.168.10.120 \
+    -src.port 62576 \
+    -dst.ip 104.123.204.164 \
+    -dst.port 443
+  brimcap ts -r result.pcap
+
+inputs:
+  - name: non-overlap1.pcapng
+    source: non-overlap.pcapng
+  - name: non-overlap2.pcapng
+    source: non-overlap.pcapng
+
+outputs:
+  - name: stdout
+    data: |
+      1583768523.826851
+      1583768523.826857
+      1583768523.826968
+      1583768523.826968
+      1583768523.827279
+      1583768523.826851
+      1583768523.826857
+      1583768523.826968
+      1583768523.826968
+      1583768523.827279
+  - name: stderr
+    data: ""

--- a/cmd/brimcap/ztests/search-notfound.yaml
+++ b/cmd/brimcap/ztests/search-notfound.yaml
@@ -1,0 +1,37 @@
+script: |
+  mkdir root
+  brimcap index -root root -r non-overlap.pcapng
+
+  brimcap search -root root \
+    -w result.pcap \
+    -ts 2020-03-10T15:42:03.826851Z \
+    -duration 428us \
+    -proto tcp \
+    -src.ip 192.168.10.120 \
+    -src.port 62576 \
+    -dst.ip 104.123.204.164 \
+    -dst.port 443
+
+  >&2 echo === 
+  brimcap search -root root \
+    -w result.pcap \
+    -ts 2020-03-09T15:42:03.826851Z \
+    -duration 428us \
+    -proto tcp \
+    -src.ip 192.168.10.54 \
+    -src.port 62576 \
+    -dst.ip 104.123.204.164 \
+    -dst.port 443
+
+
+inputs:
+  - name: non-overlap.pcapng
+
+outputs:
+  - name: stdout
+    data: ""
+  - name: stderr
+    data: |
+      {"type":"error","error":"no packets found"}
+      ===
+      {"type":"error","error":"no packets found"}

--- a/cmd/brimcap/ztests/search.yaml
+++ b/cmd/brimcap/ztests/search.yaml
@@ -1,0 +1,61 @@
+script: |
+  mkdir root
+  brimcap index -root root -r non-overlap.pcapng
+  brimcap index -root root -r alerts.pcap
+
+  brimcap search -root root \
+    -w result.pcap \
+    -ts 2015-03-05T15:04:31.278897Z \
+    -duration 15.536964s \
+    -proto tcp \
+    -src.ip 192.168.0.51 \
+    -src.port 47608 \
+    -dst.ip 85.12.30.227 \
+    -dst.port 80
+  brimcap ts -r result.pcap
+
+  echo ===
+  brimcap search -root root \
+    -w result.pcap \
+    -ts 2020-03-09T15:42:03.826851Z \
+    -duration 428us \
+    -proto tcp \
+    -src.ip 192.168.10.120 \
+    -src.port 62576 \
+    -dst.ip 104.123.204.164 \
+    -dst.port 443
+  brimcap ts -r result.pcap
+
+inputs:
+  - name: non-overlap.pcapng
+  - name: alerts.pcap
+
+outputs:
+  - name: stderr
+    data: ""
+  - name: stdout
+    data: |
+      1425567871.278897
+      1425567871.314453
+      1425567871.314461
+      1425567871.41141
+      1425567871.444042
+      1425567871.508086
+      1425567871.508095
+      1425567871.508097
+      1425567871.508099
+      1425567871.508101
+      1425567871.575635
+      1425567871.613603
+      1425567871.645149
+      1425567871.645158
+      1425567881.641794
+      1425567881.677738
+      1425567886.815577
+      1425567886.815861
+      ===
+      1583768523.826851
+      1583768523.826857
+      1583768523.826968
+      1583768523.826968
+      1583768523.827279

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/multierr v1.6.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect
 	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6
 )

--- a/go.sum
+++ b/go.sum
@@ -656,6 +656,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pcap/search.go
+++ b/pcap/search.go
@@ -25,36 +25,36 @@ type Search struct {
 	id     string
 }
 
-func NewTCPSearch(span nano.Span, flow Flow) *Search {
+func NewTCPSearch(span nano.Span, flow Flow) Search {
 	id := fmt.Sprintf("%s_tcp_%s", span.Ts.StringFloat(), flow)
-	return &Search{
+	return Search{
 		span:   span,
 		filter: genTCPFilter(flow),
 		id:     id,
 	}
 }
 
-func NewUDPSearch(span nano.Span, flow Flow) *Search {
+func NewUDPSearch(span nano.Span, flow Flow) Search {
 	id := fmt.Sprintf("%s_udp_%s", span.Ts.StringFloat(), flow)
-	return &Search{
+	return Search{
 		span:   span,
 		filter: genUDPFilter(flow),
 		id:     id,
 	}
 }
 
-func NewICMPSearch(span nano.Span, src, dst net.IP) *Search {
+func NewICMPSearch(span nano.Span, src, dst net.IP) Search {
 	id := fmt.Sprintf("icmp_%s_%s_%s", span.Ts.StringFloat(), src.String(), dst.String())
-	return &Search{
+	return Search{
 		span:   span,
 		filter: genICMPFilter(src, dst),
 		id:     id,
 	}
 }
 
-func NewRangeSearch(span nano.Span) *Search {
+func NewRangeSearch(span nano.Span) Search {
 	id := fmt.Sprintf("%s_%s_%s", span.Ts.StringFloat(), "none", "no-filter")
-	return &Search{
+	return Search{
 		span: span,
 		id:   id,
 	}
@@ -135,7 +135,7 @@ func genICMPFilter(src, dst net.IP) PacketFilter {
 }
 
 // XXX need to handle searching over multiple pcap files
-func (s *Search) Run(ctx context.Context, w io.Writer, r pcapio.Reader) error {
+func (s Search) Run(ctx context.Context, w io.Writer, r pcapio.Reader) error {
 	reader, err := s.Reader(ctx, r)
 	if err != nil {
 		return err
@@ -145,14 +145,14 @@ func (s *Search) Run(ctx context.Context, w io.Writer, r pcapio.Reader) error {
 }
 
 type SearchReader struct {
-	*Search
+	Search
 	reader pcapio.Reader
 	opts   gopacket.DecodeOptions
 	window []byte
 	buf    []byte
 }
 
-func (s *Search) Reader(ctx context.Context, r pcapio.Reader) (*SearchReader, error) {
+func (s Search) Reader(ctx context.Context, r pcapio.Reader) (*SearchReader, error) {
 	opts := gopacket.DecodeOptions{Lazy: true, NoCopy: true}
 	reader := &SearchReader{Search: s, reader: r, opts: opts}
 	if err := reader.fill(ctx); err != nil {

--- a/pcap/slicer.go
+++ b/pcap/slicer.go
@@ -13,6 +13,9 @@ func NewSlicer(seeker io.ReadSeeker, index Index, span nano.Span) (*slicer.Reade
 	if err != nil {
 		return nil, err
 	}
+	if len(slices) == 0 {
+		return nil, nil
+	}
 	return slicer.NewReader(seeker, slices)
 }
 

--- a/root.go
+++ b/root.go
@@ -1,14 +1,31 @@
 package brimcap
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 
 	"github.com/brimdata/brimcap/pcap"
-	"github.com/brimdata/zed/pkg/fs"
+	"github.com/brimdata/brimcap/pcap/pcapio"
+	fse "github.com/brimdata/zed/pkg/fs"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zbuf"
+	"golang.org/x/sync/errgroup"
 )
+
+type Search struct {
+	Span    nano.Span
+	Proto   string
+	SrcIP   net.IP
+	SrcPort uint16
+	DstIP   net.IP
+	DstPort uint16
+}
 
 type Root string
 
@@ -26,18 +43,104 @@ func (r Root) AddPcap(path string, limit int, warner zbuf.Warner) (nano.Span, er
 		return nano.Span{}, err
 	}
 
+	return index.Span(), r.AddPcapWithIndex(path, index)
+}
+
+func (r Root) AddPcapWithIndex(path string, index pcap.Index) (err error) {
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return err
+	}
 	// symlink path to root
 	if err := os.Symlink(path, r.SymlinkPath(path)); err != nil {
-		return nano.Span{}, err
+		return err
 	}
 
 	// create pcap index
-	if err = fs.MarshalJSONFile(index, r.IndexPath(path), 0644); err != nil {
+	if err := fse.MarshalJSONFile(index, r.IndexPath(path), 0644); err != nil {
 		r.DeletePcap(path)
-		return nano.Span{}, err
+		return err
+	}
+	return nil
+}
+
+func (r Root) Search(ctx context.Context, req Search, w io.Writer) error {
+	var search pcap.Search
+	// We add two microseconds to the end of the span as fudge to deal with the
+	// fact that zeek truncates timestamps to microseconds where pcap-ng
+	// timestamps have nanosecond precision.  We need two microseconds because
+	// both the base timestamp of a conn record as well as the duration time
+	// can be truncated downward.
+	span := nano.NewSpanTs(req.Span.Ts, req.Span.End()+2000)
+	flow := pcap.NewFlow(req.SrcIP, int(req.SrcPort), req.DstIP, int(req.DstPort))
+	switch req.Proto {
+	case "tcp":
+		search = pcap.NewTCPSearch(span, flow)
+	case "udp":
+		search = pcap.NewUDPSearch(span, flow)
+	case "icmp":
+		search = pcap.NewICMPSearch(span, req.SrcIP, req.DstIP)
+	default:
+		return fmt.Errorf("unsupported proto type: %s", req.Proto)
 	}
 
-	return index.Span(), nil
+	files, err := r.Pcaps()
+	if err != nil {
+		return err
+	}
+
+	group, _ := errgroup.WithContext(ctx)
+	readers := make(chan *pcap.SearchReader, len(files))
+	closers := make(chan io.Closer, len(files))
+	for _, file := range files {
+		file := file
+		group.Go(func() error {
+			pr, closer, err := file.PcapReader(span)
+			if err != nil || pr == nil {
+				return err
+			}
+
+			r, err := search.Reader(ctx, pr)
+			if err != nil {
+				closer.Close()
+				if errors.Is(err, pcap.ErrNoPcapsFound) {
+					return nil
+				}
+				return err
+			}
+
+			readers <- r
+			closers <- closer
+			return nil
+		})
+	}
+	go func() {
+		group.Wait()
+		close(readers)
+		close(closers)
+	}()
+
+	defer func() {
+		for closer := range closers {
+			closer.Close()
+		}
+	}()
+
+	var count int
+	for pr := range readers {
+		count++
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, err := io.Copy(w, pr); err != nil {
+			return err
+		}
+	}
+	err = group.Wait()
+	if err == nil && count == 0 {
+		return pcap.ErrNoPcapsFound
+	}
+	return err
 }
 
 func (r Root) SymlinkPath(path string) string {
@@ -59,6 +162,58 @@ func (r Root) DeletePcap(path string) error {
 		err2 = nil
 	}
 	return err2
+}
+
+type File struct {
+	LinkPath  string
+	IndexPath string
+}
+
+func (f File) PcapReader(span nano.Span) (pcapio.Reader, io.Closer, error) {
+	index, err := pcap.LoadIndex(f.IndexPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	file, err := os.Open(f.LinkPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	slicer, err := pcap.NewSlicer(file, index, span)
+	if err != nil {
+		file.Close()
+		return nil, nil, err
+	}
+	if slicer == nil {
+		file.Close()
+		return nil, nil, nil
+	}
+
+	pcapReader, err := pcapio.NewReader(slicer)
+	if err != nil {
+		file.Close()
+		return nil, nil, err
+	}
+
+	return pcapReader, file, nil
+}
+
+func (r Root) Pcaps() ([]File, error) {
+	entries, err := os.ReadDir(string(r))
+	if err != nil {
+		return nil, err
+	}
+	var files []File
+	for _, entry := range entries {
+		if entry.Type()&fs.ModeSymlink != 0 {
+			files = append(files, File{
+				LinkPath:  r.SymlinkPath(entry.Name()),
+				IndexPath: r.IndexPath(entry.Name()),
+			})
+		}
+	}
+	return files, nil
 }
 
 func (r Root) join(els ...string) string {

--- a/root.go
+++ b/root.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/brimdata/brimcap/pcap"
 	"github.com/brimdata/brimcap/pcap/pcapio"
-	fse "github.com/brimdata/zed/pkg/fs"
+	pkgfs "github.com/brimdata/zed/pkg/fs"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zbuf"
 	"golang.org/x/sync/errgroup"
@@ -57,7 +57,7 @@ func (r Root) AddPcapWithIndex(path string, index pcap.Index) (err error) {
 	}
 
 	// create pcap index
-	if err := fse.MarshalJSONFile(index, r.IndexPath(path), 0644); err != nil {
+	if err := pkgfs.MarshalJSONFile(index, r.IndexPath(path), 0644); err != nil {
 		r.DeletePcap(path)
 		return err
 	}
@@ -89,7 +89,7 @@ func (r Root) Search(ctx context.Context, req Search, w io.Writer) error {
 		return err
 	}
 
-	group, _ := errgroup.WithContext(ctx)
+	group, ctx := errgroup.WithContext(ctx)
 	readers := make(chan *pcap.SearchReader, len(files))
 	closers := make(chan io.Closer, len(files))
 	for _, file := range files {

--- a/root.go
+++ b/root.go
@@ -129,9 +129,6 @@ func (r Root) Search(ctx context.Context, req Search, w io.Writer) error {
 	var count int
 	for pr := range readers {
 		count++
-		if err := ctx.Err(); err != nil {
-			return err
-		}
 		if _, err := io.Copy(w, pr); err != nil {
 			return err
 		}


### PR DESCRIPTION
Add the brimcap launch command. brimcap launch takes as argument the time span,
protocol, source ip and port, and destination ip and port describing
a connection and searches through all the indexed pcaps in the BRIMCAP_ROOT
packets matching the description. If the search returns a result the packets
are opened in wireshark.

Additional changes:
- add brimcap search: the same thing as brimcap launch except it writes the
  search result as a pcap file.
- brimcap index -root: If the -root flag is provided brimcap index will create
  a index of the pcap in the BRIMCAP_ROOT.

Closes #7