### PR TITLE
Analyzer process: configurable working directory

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -27,7 +27,6 @@ type analyzer struct {
 	cancel   context.CancelFunc
 	config   Config
 	ctx      context.Context
-	wd       string
 	once     sync.Once
 	procErr  error
 	procDone chan struct{}
@@ -35,6 +34,7 @@ type analyzer struct {
 	records  int64
 	tailer   *ztail.Tailer
 	warner   zbuf.Warner
+	workdir  string
 	zctx     *zson.Context
 	zreader  zbuf.Reader
 }
@@ -94,25 +94,25 @@ func (p *analyzer) run() (err error) {
 		}
 	}
 
-	logdir := p.config.WorkDir
-	if logdir == "" {
-		if logdir, err = os.MkdirTemp("", "brimcap-"); err != nil {
+	p.workdir = p.config.WorkDir
+	if p.workdir == "" {
+		if p.workdir, err = os.MkdirTemp("", "brimcap-"); err != nil {
 			close(p.procDone)
 			return err
 		}
 	}
 
-	process, err := newLauncher(p.config)(p.ctx, logdir, p.reader)
+	process, err := newLauncher(p.config)(p.ctx, p.workdir, p.reader)
 	if err != nil {
 		close(p.procDone)
-		os.RemoveAll(logdir)
+		p.removeWorkDir()
 		return err
 	}
 
-	tailer, err := ztail.New(p.zctx, logdir, p.config.ReaderOpts, p.config.Globs...)
+	tailer, err := ztail.New(p.zctx, p.workdir, p.config.ReaderOpts, p.config.Globs...)
 	if err != nil {
 		close(p.procDone)
-		os.RemoveAll(logdir)
+		p.removeWorkDir()
 		return err
 	}
 	tailer.WarningHandler(p.warner)
@@ -130,13 +130,12 @@ func (p *analyzer) run() (err error) {
 
 	p.zreader = tailer
 	p.tailer = tailer
-	p.wd = logdir
 	if shaper != nil {
 		p.zreader, err = driver.NewReader(p.ctx, shaper, p.zctx, p.zreader)
 		if err != nil {
 			close(p.procDone)
 			tailer.Close()
-			os.RemoveAll(logdir)
+			p.removeWorkDir()
 			return err
 		}
 	}
@@ -151,6 +150,13 @@ func (p *analyzer) BytesRead() int64 {
 	return p.reader.Bytes()
 }
 
+func (p *analyzer) removeWorkDir() error {
+	if p.config.WorkDir == "" {
+		return os.RemoveAll(p.workdir)
+	}
+	return nil
+}
+
 // Close shutdowns the current process (if it is still active), shutdowns the
 // go-routine tailing for logs and removes the temporary log directory.
 func (p *analyzer) Close() (err error) {
@@ -161,10 +167,8 @@ func (p *analyzer) Close() (err error) {
 		err = p.tailer.Close()
 	}
 
-	if p.config.WorkDir == "" {
-		if err2 := os.RemoveAll(p.wd); err == nil {
-			err = err2
-		}
+	if err2 := p.removeWorkDir(); err == nil {
+		err = err2
 	}
 	return err
 }

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	StderrPath string         `yaml:"stderr"`
 	// WorkDir if set uses the provided directory as the working directory for
 	// the launched analyzer process. Normally a temporary directory is created
-	// then deleted when the process is complete, if WorkDir is set the working
+	// then deleted when the process is complete. If WorkDir is set the working
 	// directory will not be deleted.
 	WorkDir string `yaml:"workdir"`
 }

--- a/analyzer/config.go
+++ b/analyzer/config.go
@@ -16,6 +16,11 @@ type Config struct {
 	Shaper     string         `yaml:"shaper"`
 	StdoutPath string         `yaml:"stdout"`
 	StderrPath string         `yaml:"stderr"`
+	// WorkDir if set uses the provided directory as the working directory for
+	// the launched analyzer process. Normally a temporary directory is created
+	// then deleted when the process is complete, if WorkDir is set the working
+	// directory will not be deleted.
+	WorkDir string `yaml:"workdir"`
 }
 
 func LoadYAMLConfigFile(path string) ([]Config, error) {

--- a/cmd/brimcap/ztests/analyze-process-error.yaml
+++ b/cmd/brimcap/ztests/analyze-process-error.yaml
@@ -10,13 +10,13 @@ inputs:
     data: |
       analyzers:
         - cmd: ./errorproc.sh
-          globs: ["*.zson"] # so the ztail will not try to read errorproc.sh
+          globs: ["*.zson"] # so ztail will not try to read errorproc.sh
           workdir: wd
   - name: config2.yaml
     data: |
       analyzers:
         - cmd: ./errorproc.sh
-          globs: ["*.zson"] # so the ztail will not try to read errorproc.sh
+          globs: ["*.zson"] # so ztail will not try to read errorproc.sh
           stderr: stderr.out
           workdir: wd
   - name: errorproc.sh

--- a/cmd/brimcap/ztests/analyze-process-error.yaml
+++ b/cmd/brimcap/ztests/analyze-process-error.yaml
@@ -1,7 +1,5 @@
 script: |
-  export PATH=$(pwd):$PATH
-  chmod +x errorproc.sh
-
+  chmod +x errorproc.sh && mkdir wd && cp errorproc.sh wd
   brimcap analyze -config=config1.yaml alerts.pcap 
   >&2 echo === 
   brimcap analyze -config=config2.yaml alerts.pcap
@@ -11,12 +9,16 @@ inputs:
   - name: config1.yaml
     data: |
       analyzers:
-        - cmd: errorproc.sh
+        - cmd: ./errorproc.sh
+          globs: ["*.zson"] # so the ztail will not try to read errorproc.sh
+          workdir: wd
   - name: config2.yaml
     data: |
       analyzers:
-        - cmd: errorproc.sh
+        - cmd: ./errorproc.sh
+          globs: ["*.zson"] # so the ztail will not try to read errorproc.sh
           stderr: stderr.out
+          workdir: wd
   - name: errorproc.sh
     data: |
       #!/bin/bash

--- a/cmd/brimcap/ztests/analyze-process-error.yaml
+++ b/cmd/brimcap/ztests/analyze-process-error.yaml
@@ -1,5 +1,5 @@
 script: |
-  chmod +x errorproc.sh && mkdir wd && cp errorproc.sh wd
+  chmod +x errorproc.sh && mkdir wd && mv errorproc.sh wd
   brimcap analyze -config=config1.yaml alerts.pcap 
   >&2 echo === 
   brimcap analyze -config=config2.yaml alerts.pcap


### PR DESCRIPTION
Add workdir field to analyzer configuration. If workdir is set, the analyzer
process usees this directory as the current working directory for the executed
process.

Closes #16