### PR TITLE
Add start of wiki & an Action to publish to it

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,19 @@
+name: Publish documentation to GitHub Wiki
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Upload Documentation to Wiki
+        uses: brimdata/github-wiki-publish-action@v1
+        with:
+          path: "docs"
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ variable.
 export PATH=$PATH:/Path/To/brimcap
 ```
 
+## Having a problem?
+
+Please browse the [wiki](https://github.com/brimdata/brimcap/wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimdata/brimcap/wiki/Troubleshooting#opening-an-issue).
+
 ## Build From Source
 
 To build from source, Go version 1.16 or later is required.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,8 @@
+# Welcome
+
+Welcome to the Brimcap wiki. These pages provide additional information for
+your effective use of Brimcap.
+
+## Support Resources
+
+- [[Troubleshooting]]

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,59 @@
+# Troubleshooting
+
+If you're having a problem with Brimcap, please browse the following sections
+before you [open an issue](#opening-an-issue).
+
+- [Gathering Info](#gathering-info)
+  * [Sensitive Information (important!)](#sensitive-information-important)
+  * [Screenshots/Videos](#screenshotsvideos)
+  * [Sample Packet Captures](#sample-packet-captures)
+  * [Large Files](#large-files)
+- [Opening an Issue](#opening-an-issue)
+
+# Gathering Info
+
+Before [opening an issue](#opening-an-issue), or while debugging a
+previously-opened issue, there's detail you can gather that may help us more
+quickly provide you with a resolution.
+
+## Sensitive Information (important!)
+
+For all information described in this section, we understand that some of it
+may be of a sensitive nature such that you don't feel you can attach it
+directly to a public GitHub Issue. If you can crop, blur, or otherwise modify
+the information before attaching, please do. If you feel you could share such
+information only privately, please notify us on [public Slack](https://www.brimsecurity.com/join-slack/)
+and we can arrange to receive it from you in a private 1-on-1 chat.
+
+## Screenshots/Videos
+
+If you think you've encountered a bug that's specific to how Brimcap interacts
+with the Brim app, a screenshot or recorded desktop video of your Brim app
+that includes the error message or unexpected behavior may help us a lot. If
+you can annotate your media with arrows, text, or other detail, even better.
+The same is true if you're submitting a detailed feature request.
+
+## Sample Packet Captures
+
+If your problem involes a pcap file, we'll likely be able to debug much quicker
+if you can attach a sample pcap file to your issue. If you are able to
+reproduce the issue using a small pcap that you're certain does not contain
+sensitive information, that would be ideal.
+
+## Large Files
+
+If you have a video or sample pcap that is too large to attach to a GitHub
+Issue, please upload it to the file-sharing service of your choosing and paste
+a link to it in your issue.
+
+# Opening an Issue
+
+Before/when [opening a new issue](https://github.com/brimdata/brimcap/issues/new/choose),
+you can help us out by doing the following:
+
+* Browse the existing [open issues](https://github.com/brimdata/brimcap/issues?q=is%3Aissue+is%3Aopen). If you confirm you're hitting one of those, please add a comment to it rather than opening a new issue.
+* [Gather info](#gathering-info) that that may help in reproducing the issue and testing a fix, and attach it to your issue.
+* Feel free to chat with the team on the [public Slack](https://www.brimsecurity.com/join-slack/) before/after opening an issue.
+* When you open a new issue, its initial text will include a template with standard info that will almost always be needed. Please include detail for all areas of the template.
+
+Thanks for helping us support the Brim community!

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,0 +1,1 @@
+Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,3 @@
+**Support Resources**
+  
+- [[Troubleshooting]]


### PR DESCRIPTION
As the pcap/Zeek/Suricata-centric functionality migrates from the Brim app into Brimcap, docs regarding such functionality should likely move as well. A couple examples of wiki-bound items that are already in the queue are the move of the Zeek compatibility doc (brimdata/zed#2458) and a description of how the Suricata shaper works and could be customized (#8).

To make way for this, I'm replicating the approach we've used in the Brim repo where the original copy of the materials can live in a `docs/` directory in the main repo and we can use a GitHub Action that publishes its contents to the wiki mini-repo that lives off to its side. This way the revision history of the docs are kept with everything else.

To get the wiki started, I've repurposed some of the Troubleshooting content from the Brim wiki. I'll continue migrating more gradually over time.