### PR TITLE
Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us fix a problem in Brimcap
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+Before opening a new issue, please make sure you've reviewed the troubleshooting guide:
+https://github.com/brimdata/brimcap/wiki/Troubleshooting
+
+**Describe the bug**
+[A description of what the bug is]
+
+**To Reproduce**
+[Steps to reproduce the behavior]
+
+**Expected behavior**
+[A description of what you expected to happen]
+
+**Screenshots**
+[If applicable, add screenshots to help explain your problem]
+
+**Desktop Info**
+[Please complete the following information]
+ - OS: [e.g. Windows, Linux, macOS]
+ - Brimcap Version: [output of "brimcap -version"]
+ - Brim Version (if applicable): [copy from **Help > About Brim** on Windows and Linux, or **Brim > About Brim** on macOS]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea to improve Brimcap
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Before opening a new issue, please make sure you've reviewed the troubleshooting guide:
+https://github.com/brimdata/brimcap/wiki/Troubleshooting#opening-an-issue
+
+**Is your feature request related to a problem? Please describe.**
+[For example: "I'm always frustrated when..."]
+
+**Describe the solution you'd like**
+[What you want to happen]


### PR DESCRIPTION
To help our users file good issues, I'm repurposing the templates we've been using for the Brim desktop app. Since these point at content from the Brimcap wiki, I'll hold off on merging it until after #30 gets merged.