### PR TITLE
Add Actions for a markdown link checker

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,0 +1,3 @@
+{
+  "retryOn429": true
+}

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,30 @@
+name: Markdown link check
+
+on:
+  schedule:
+    - cron: '5 8 * * *'
+  pull_request:
+    paths:
+      - '**.md'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: .github/workflows/markdown-link-check-config.json
+    - name: Inform Slack users of link check failures
+      uses: tiloio/slack-webhook-action@v1.1.2
+      if: ${{ failure() && steps.extract_branch.outputs.branch == 'main' }}
+      with: 
+        slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_DOCS }}
+        slack_json: |
+          {
+            "username": "markdown-link-check",
+            "text": "Markdown link check failed: https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}"
+          }


### PR DESCRIPTION
I've enabled these in our other repos that contain markdown docs so we don't have persistent dead links. Like the others, this is rigged up to run nightly and send its output to our internal Slack #docs channel so only people who want to be bothered by the failures have to see them.

I've already made the change so our org-level secret needed to send to Slack is available to the Brimcap repo, so this should be able to start running once it gets merged.