### PR TITLE
Zed update through "split AST into a DAG piece and a parser piece" by…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/brimdata/brimcap
 go 1.16
 
 require (
-	github.com/brimdata/zed v0.29.1-0.20210411000450-223a175d1f97
+	github.com/brimdata/zed v0.29.1-0.20210416002200-cc95cbc252d4
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/mock v1.5.0
 	github.com/google/gopacket v1.1.19

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/brimdata/zed v0.29.1-0.20210411000450-223a175d1f97 h1:18+gTOeJ9niGyJka3j6ilPcoOK4jhCMSZfu8IMO+X9s=
-github.com/brimdata/zed v0.29.1-0.20210411000450-223a175d1f97/go.mod h1:dIr7HFlxlvz1QrSwo145MES1XAwdhYZokgxGh9ld7+0=
+github.com/brimdata/zed v0.29.1-0.20210416002200-cc95cbc252d4 h1:n7Ct13KUOYIY5vpDmmXcE+dFC4GeW2HB/ZEciw/Weo0=
+github.com/brimdata/zed v0.29.1-0.20210416002200-cc95cbc252d4/go.mod h1:dIr7HFlxlvz1QrSwo145MES1XAwdhYZokgxGh9ld7+0=
 github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e h1:oJCXMss/3rg5F6Poy9wG3JQusc58Mzk5B9Z6wSnssNE=
 github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e/go.mod h1:errmMKH8tTB49UR2A8C8DPYkyudelsYJwJFaZHQ6ik8=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=


### PR DESCRIPTION
… mccanne

This is an auto-generated commit with a Zed dependency update. The Zed PR
https://github.com/brimdata/zed/pull/2553, authored by @mccanne,
has been merged.

split AST into a DAG piece and a parser piece

This commit separates the AST into a execution-oriented piece
that describes the computational flowgraph (DAG) and a parser-oriented
piece that represents the output of the Zed language grammar.

The optimization logic and query planner operates exlusively on
the DAG and workers pass DAG fragments around to execute a
distributed query.

The AST should not appear in any API and we should evolve
the outward facing search API to use either a text Zed language
description of the query or a DAG description.

At some point, we will have a parser that takes a canonical form
DAG language input and produces the DAG data structure, which
will be handy for test and debug.

Closes brimdata/zed#2163
Closes brimdata/zed#2255