### PR TITLE
Delete successful advance zed branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
         run: |
           git cherry-pick ${{ github.sha }}
           git push
+      - name: Delete branch
+        run: git push origin --delete ${{ github.ref }}
 
   advance-zed-failure:
     name: Advance Zed failure


### PR DESCRIPTION
If an advanced zed branch has been successfully merged to main, delete the
branch.