### PR TITLE
Include version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "brimcap",
+  "version": "0.0.2-dev",
   "files": [
     "build/dist"
   ],


### PR DESCRIPTION
When managing the zq `package.json` pointer advances in Brim, Michael Brown taught me the trick of doing `npm install https://github.com/brimsec/zq#tag-or-commit-hash` on the Brim side rather than manually editing `package.json` and `package-lock.json`. Thinking it'd be a good idea to similarly advance the Brimcap pointer in Brim, I tried doing the equivalent but it failed:

```
$ npm install https://github.com/brimdata/brimcap#a011e281d3a48e0d6b20ccd2be6b3e250d70c59a
npm ERR! Can't install git+https://github.com/brimdata/brimcap.git#a011e281d3a48e0d6b20ccd2be6b3e250d70c59a: Missing package version
```

It looks like it requires the `version` field to be present in the `package.json` of the dependency being installed, such as is present for Zed but wasn't for Brimcap, so I've added it here. I've started it off with the same kind of workflow we've always had for the zq dependency: Set the version string to the most recent release tag followed by `-dev`, with intent to advance that next time we package a tagged Brimcap release. This tested out successfully using the commit for this branch.

```
$ npm install https://github.com/brimdata/brimcap#1aa7d51b60dbf517de12c3ace5bb030ac738152b
...
$ grep brimcap package.json package-lock.json 
package.json:    "brimcap": "git+https://github.com/brimdata/brimcap.git#1aa7d51b60dbf517de12c3ace5bb030ac738152b",
package-lock.json:    "brimcap": {
package-lock.json:      "version": "git+https://github.com/brimdata/brimcap.git#1aa7d51b60dbf517de12c3ace5bb030ac738152b",
package-lock.json:      "from": "git+https://github.com/brimdata/brimcap.git#1aa7d51b60dbf517de12c3ace5bb030ac738152b",
```