### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## v0.0.3
+
+* Remove the `brimcap launch` command, since Brim will do `brimcap search` (#56)
+* Adjust `brimcap load` to use the endpoints in `zed lake serve` (#63)
+* Fix an issue with `pcap_path` not being stored as an absolute path, which caused problems extracting flows (#67)
+* Add the hidden `brimcap migrate` command which Brim will use for migrating legacy Space data (#66)
+
+## v0.0.2
+
+* Fix an issue where use of symlinks in the root was preventing `brimcap load` from working on Windows (#39)
+
+## v0.0.1
+
+* Initial release, still being tested.


### PR DESCRIPTION
As I'm starting to create tagged Brimcap releases, I realize we might as well have a `CHANGELOG.md` that collects the release notes all in one place.

Like I do for the Brim and Zed repos, in the future I can use a workflow where I put up a PR with the changelog diffs as a prerequisite for tagging a release, and once the PR is approved/merged I can tag the release at that new commit. Then of course the same release notes from the changelog go to the GitHub Releases page.