### PR TITLE
migrate: fix windows bug

### DIFF
--- a/cmd/brimcap/migrate/command.go
+++ b/cmd/brimcap/migrate/command.go
@@ -221,6 +221,7 @@ func (m *migration) migrateData(ctx context.Context) error {
 		}
 		return err
 	}
+	defer f.Close()
 	if _, err = m.conn.LogPostReaders(ctx, m.poolID, nil, f); err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes the "The process cannot access the file because it is being used by
another process" error encountered when migrating on windows.

Closes #78