### PR TITLE
brimcap migrate abort: error messages

### DIFF
--- a/cmd/brimcap/migrate/command.go
+++ b/cmd/brimcap/migrate/command.go
@@ -304,6 +304,6 @@ func (m *migration) abort() {
 		m.logErr(fmt.Sprintf("error deleting pool from aborted migration: %v", err))
 	}
 	if err := os.Remove(m.brimcapEntry); err != nil {
-		m.logErr(fmt.Sprintf("error brimcap entry from aborted migration: %v", err))
+		m.logErr(fmt.Sprintf("error removing brimcap entry from aborted migration: %v", err))
 	}
 }

--- a/cmd/brimcap/migrate/command.go
+++ b/cmd/brimcap/migrate/command.go
@@ -300,6 +300,10 @@ func (m *migration) removeSpace() error {
 }
 
 func (m *migration) abort() {
-	m.conn.PoolDelete(context.Background(), m.poolID)
-	os.Remove(m.brimcapEntry)
+	if err := m.conn.PoolDelete(context.Background(), m.poolID); err != nil {
+		m.logErr(fmt.Sprintf("error deleting pool from aborted migration: %v", err))
+	}
+	if err := os.Remove(m.brimcapEntry); err != nil {
+		m.logErr(fmt.Sprintf("error brimcap entry from aborted migration: %v", err))
+	}
 }


### PR DESCRIPTION
If an error occurs during an abort of a space migration, log the error
message.