### PR TITLE
Graceful shutdown on sigterm

### DIFF
--- a/cmd/brimcap/analyze/command.go
+++ b/cmd/brimcap/analyze/command.go
@@ -3,7 +3,6 @@ package analyze
 import (
 	"errors"
 	"flag"
-	"os"
 
 	"github.com/brimdata/brimcap/analyzer"
 	"github.com/brimdata/brimcap/cli"
@@ -12,7 +11,6 @@ import (
 	"github.com/brimdata/zed/cli/outputflags"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/nano"
-	"github.com/brimdata/zed/pkg/signalctx"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
@@ -64,17 +62,15 @@ func (c *Command) Run(args []string) (err error) {
 		return errors.New("expected 1 pcapfile arg")
 	}
 
-	if err := c.Init(&c.out, &c.analyzeflags); err != nil {
+	ctx, cleanup, err := c.InitWithContext(&c.out, &c.analyzeflags)
+	if err != nil {
 		return err
 	}
-	defer c.Cleanup()
+	defer cleanup()
 
 	if err := c.AddRunnersToPath(); err != nil {
 		return err
 	}
-
-	ctx, cancel := signalctx.New(os.Interrupt)
-	defer cancel()
 
 	emitter, err := c.out.Open(ctx, storage.NewLocalEngine())
 	if err != nil {

--- a/cmd/brimcap/cut/command.go
+++ b/cmd/brimcap/cut/command.go
@@ -96,10 +96,11 @@ func max(in []int) int {
 }
 
 func (c *Command) Run(args []string) error {
-	defer c.Cleanup()
-	if err := c.Init(); err != nil {
+	cleanup, err := c.Command.Init()
+	if err != nil {
 		return err
 	}
+	defer cleanup()
 	var cuts []int
 	for _, s := range args {
 		var err error

--- a/cmd/brimcap/index/command.go
+++ b/cmd/brimcap/index/command.go
@@ -77,11 +77,11 @@ func (c *Command) Init() error {
 }
 
 func (c *Command) Run(args []string) (err error) {
-	defer c.Cleanup()
-	if err := c.Command.Init(&c.rootflags); err != nil {
+	cleanup, err := c.Command.Init(&c.rootflags, c)
+	if err != nil {
 		return err
 	}
-
+	defer cleanup()
 	if c.rootflags.IsSet {
 		if c.inputFile == "-" {
 			return errors.New("cannot write pcap from stdin to brimcap root")

--- a/cmd/brimcap/info/command.go
+++ b/cmd/brimcap/info/command.go
@@ -39,10 +39,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	defer c.Cleanup()
-	if err := c.Init(); err != nil {
+	cleanup, err := c.Command.Init()
+	if err != nil {
 		return err
 	}
+	defer cleanup()
 	if len(args) != 1 {
 		return errors.New("pcap info takes a single file as input")
 	}

--- a/cmd/brimcap/migrate/command.go
+++ b/cmd/brimcap/migrate/command.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"path/filepath"
 
 	"github.com/brimdata/brimcap"
@@ -94,15 +93,14 @@ type pcapMetadata struct {
 }
 
 func (c *Command) Run(args []string) error {
-	if err := c.Command.Init(&c.rootflags); err != nil {
+	ctx, cleanup, err := c.Command.InitWithContext(&c.rootflags)
+	if err != nil {
 		return err
 	}
-	defer c.Cleanup()
+	defer cleanup()
 	if c.zqdroot == "" {
 		return errors.New("flag -zqd is required")
 	}
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
 	c.conn = client.NewConnection()
 	if _, err := c.conn.Ping(ctx); err != nil {
 		return err

--- a/cmd/brimcap/slice/command.go
+++ b/cmd/brimcap/slice/command.go
@@ -2,7 +2,6 @@ package slice
 
 import (
 	"bufio"
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -96,10 +95,11 @@ func parseSpan(sfrom, sto string) (nano.Span, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	defer c.Cleanup()
-	if err := c.Init(); err != nil {
+	ctx, cleanup, err := c.Command.InitWithContext()
+	if err != nil {
 		return err
 	}
+	defer cleanup()
 	if c.indexFile != "" && c.inputFile == "-" {
 		return errors.New("stdin cannot be used with an index file; use -r to specify the pcap file")
 	}
@@ -171,5 +171,5 @@ func (c *Command) Run(args []string) error {
 	} else {
 		search = pcap.NewRangeSearch(span)
 	}
-	return search.Run(context.TODO(), out, pcapReader)
+	return search.Run(ctx, out, pcapReader)
 }

--- a/cmd/brimcap/ts/command.go
+++ b/cmd/brimcap/ts/command.go
@@ -41,10 +41,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	defer c.Cleanup()
-	if err := c.Init(); err != nil {
+	ctx, cleanup, err := c.Command.InitWithContext()
+	if err != nil {
 		return err
 	}
+	defer cleanup()
 	if len(args) != 0 {
 		return errors.New("pcap ts takes no arguments")
 	}
@@ -71,6 +72,9 @@ func (c *Command) Run(args []string) error {
 		defer out.Close()
 	}
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		block, typ, err := reader.Read()
 		if err != nil {
 			if err == io.EOF {


### PR DESCRIPTION
Add SIGTERM to the list of signals we listen to for graceful shutdown of
a brimcap command.