### PR TITLE
Change "." to "this" in Suricata shaper

### DIFF
--- a/cli/analyzecli/suricata.zed
+++ b/cli/analyzecli/suricata.zed
@@ -45,4 +45,4 @@ type alert = {
 	community_id: bstring
 }
 
-filter event_type=="alert" | put . := shape(alert) | rename ts := timestamp
+filter event_type=="alert" | put this := shape(alert) | rename ts := timestamp


### PR DESCRIPTION
When doing other shaper/typing work like brimdata/zed#2781 and brimdata/zed#2782, I've been making the change of using `this` to refer to the current record rather than the prior `.`, which made me realize this shaper could benefit from the same treatment.