### PR TITLE
Brimcap README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,64 @@
 
 ![Image of brimcap analyze](https://github.com/brimdata/brimcap/raw/main/brimcap.gif)
 
-A command line utility for converting pcaps into the flexible, searchable
-zng data format as seen in the [Brim desktop
-app](https://github.com/brimdata/brim) and the [zq command line
-utility](https://github.com/brimdata/zed).
+A command line utility for converting [pcaps](https://en.wikipedia.org/wiki/Pcap#:~:text=In%20the%20field%20of%20computer,not%20the%20API's%20proper%20name.)
+into the flexible, searchable [Zed data formats](https://github.com/brimdata/zed/tree/main/docs/formats/README.md)
+as seen in the [Brim desktop app](https://github.com/brimdata/brim) and
+the [`zq` command line utility](https://github.com/brimdata/zed/tree/main/cmd/zed#zq).
 
 ## Quickstart
 
-1. [Install brimcap](#install)
+1. [Install brimcap](#standalone-install)
 2. Have a pcap handy (or download a [sample pcap](https://wiki.wireshark.org/SampleCaptures))
 3. Run `brimcap analyze`
    ```
    brimcap analyze sample.pcap > sample.zng
    ```
-4. Explore with [zq](https://github.com/brimdata/zed) 
+4. Explore with [zq](https://github.com/brimdata/zed/tree/main/cmd/zed#zq)
    ```
-   zq -z "zeek=count(has(_path)), alerts=count(has(event_type='alert'))" sample.zng
+   zq -z 'zeek:=count(has(_path)), alerts:=count(has(event_type=="alert"))' sample.zng
    ```
 
 ## Usage with Brim desktop app
 
-The output from `analyze` can be automatically loaded into the
-[Brim desktop app](https://github.com/brimdata/brim) using the `brimcap load`
-command (builds for linux, macOS and windows available)\*:
+brimcap is bundled with the [Brim desktop app](https://github.com/brimdata/brim).
+Whenever a pcap is imported into Brim, the app executes `brimcap load` to
+generate output equivalent to that from `brimcap analyze`, then those logs are
+imported into a [Pool in the Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
+behind Brim. `brimcap load` also populates a pcap index that allows for
+quick extraction of flows via Brim's **Packets** button, which the app performs
+by executing a `brimcap search` command.
 
-1. Have the Brim desktop app running.
-2. Run the `brimcap load` command: `brimcap load sample.pcap`
+If Brim is running, you can perform these `load` operations from your shell,
+which may prove useful for automation or batch import of many pcaps to the same
+Pool. The [Custom Brimcap Config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config)
+article shows example command lines along with other advanced configuration
+options. When used with Brim, you should typically use the `brimcap` binary
+found in Brim's `zdeps` directory (as described in the article), since this
+version should be API-compatible with that version of Brim and its Zed backend.
 
-\* A more seamless integration is coming soon.
+## Standalone Install
 
-## Install
+If you're working with brimcap separate from the Brim app, prebuilt packages
+can be found in the [releases section](https://github.com/brimdata/brimcap/releases)
+of the brimcap GitHub repo.
 
-The prebuilt brimcap package can found in the [releases
-section](https://github.com/brimdata/brimcap/releases) of the brimcap Github
-repo.
-
-The release includes a special brimdata build of
-[zeek](https://github.com/brimdata/zeek) and
-[suricata](https://github.com/brimdata/build-suricata) that is preconfigured to
-provide a good experience out of the box for brimcap analyze.
-
-Unzip the artifact and add the brimcap directory to your $PATH environment
+Unzip the artifact and add the brimcap directory to your `$PATH` environment
 variable.
 
 ```
-export PATH=$PATH:/Path/To/brimcap
+export PATH="$PATH:/Path/To/brimcap"
 ```
 
-## Having a problem?
+## Included Analyzers
 
-Please browse the [wiki](https://github.com/brimdata/brimcap/wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimdata/brimcap/wiki/Troubleshooting#opening-an-issue).
+brimcap includes special builds of [Zeek](https://github.com/brimdata/zeek)
+and [Suricata](https://github.com/brimdata/build-suricata) that were created by
+the core development team at Brim Data. These builds are preconfigured to
+provide a good experience out-of-the-box for generating logs from pcaps using
+brimcap. If you wish to use your own customized Zeek/Suricata or introduce
+other pcap analysis tools, this is described in the [Custom Brimcap
+Config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config) article.
 
 ## Build From Source
 
@@ -65,9 +73,8 @@ cd brimcap
 make build
 ```
 
-`make build` will download the brimdata prebuilt / preconfigured zeek and
-suricata artifacts, compile the brimcap binary and package them into
-`build/dist`.
+`make build` will download the prebuilt/preconfigured Zeek and Suricata
+artifacts, compile the brimcap binary and package them into `build/dist`.
 
 The executables will be located here:
 ```
@@ -76,6 +83,13 @@ The executables will be located here:
 ./build/dist/suricata/suricatarunner
 ```
 
+## Having a problem?
+
+Please browse the [wiki](https://github.com/brimdata/brimcap/wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimdata/brimcap/wiki/Troubleshooting#opening-an-issue).
+
+## Join the Community
+
+Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!
 
 [ci-img]: https://github.com/brimdata/brimcap/actions/workflows/ci.yaml/badge.svg
 [ci]: https://github.com/brimdata/brimcap/actions/workflows/ci.yaml


### PR DESCRIPTION
Now that the [https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config) article exists, I wanted to link to it from the README. At that point I noticed a bunch of other stuff that could stand to be updated, so here we have it!

(FWIW, my personal preference would be to capitalize "Brimcap" when speaking about the tool in the abstract and say `brimcap` in fixed-width lowercase when talking about invoking the command at the shell. However, it seems I'm often outvoted on these topics as we get down to the "tooling" layer, so I've attempted to go with the flow of what was there already.)