### PR TITLE
Point to Suricata artifact v5.0.3-brim2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION = $(shell git describe --tags --dirty --always)
 LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 ZED_VERSION := $(shell go list -f {{.Version}} -m github.com/brimdata/zed)
 
-SURICATATAG = v5.0.3-brim1
+SURICATATAG = v5.0.3-brim2
 SURICATAPATH = suricata-$(SURICATATAG)
 ZEEKTAG = v3.2.1-brim10
 ZEEKPATH = zeek-$(ZEEKTAG)


### PR DESCRIPTION
brimdata/build-suricata#62 contains the backstory of why we've created an updated Suricata release artifact. I just tested it out on Arch Linux (the platform where #18 was first reported) by starting from an install of [https://storage.googleapis.com/brimsec-releases/brim/v0.25.0-prerelease-95581f92.0/linux/Brim-0.25.0-prerelease-95581f92.0.deb,](https://storage.googleapis.com/brimsec-releases/brim/v0.25.0-prerelease-95581f92.0/linux/Brim-0.25.0-prerelease-95581f92.0.deb,) reproducing the symptom reported in #18, then manually unpacking the [v5.0.3-brim2](https://github.com/brimdata/build-suricata/releases/tag/v5.0.3-brim2) artifact in place of the original one at the appropriate location under `/opt/Brim`, at which point I tested again and confirmed I could now successfully import pcaps without the "magic" errors. I then repeated the same test on CentOS 8 and Ubuntu 18.04 just to make extra sure we didn't regress on the major distros that never had this problem, and the test worked out fine on those also. Therefore I think we're ready for a new Brimcap artifact we can point Brim at, then share it the beta user who most recently bumped into it again.

Fixes #18