### PR TITLE
Update Brimcap docs for phase-out of "brimcap load" (for merge with brim/1716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Whenever a pcap is imported into Brim, the app takes the following steps:
 
 3. `brimcap index` is invoked to populate a local pcap index that allows for
    quick extraction of flows via Brim's **Packets** button, which the app
-   performs by executing a `brimcap search` command.
+   performs by invoking `brimcap search`.
 
 If Brim is running, you can perform these same  operations from your shell,
 which may prove useful for automation or batch import of many pcaps to the same

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ the [`zq` command line utility](https://github.com/brimdata/zed/tree/main/cmd/ze
 1. [Install brimcap](#standalone-install)
 2. Have a pcap handy (or download a [sample pcap](https://wiki.wireshark.org/SampleCaptures))
 3. Run `brimcap analyze`
+
    ```
    brimcap analyze sample.pcap > sample.zng
    ```
@@ -23,14 +24,19 @@ the [`zq` command line utility](https://github.com/brimdata/zed/tree/main/cmd/ze
 ## Usage with Brim desktop app
 
 brimcap is bundled with the [Brim desktop app](https://github.com/brimdata/brim).
-Whenever a pcap is imported into Brim, the app executes `brimcap load` to
-generate output equivalent to that from `brimcap analyze`, then those logs are
-imported into a [Pool in the Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
-behind Brim. `brimcap load` also populates a pcap index that allows for
-quick extraction of flows via Brim's **Packets** button, which the app performs
-by executing a `brimcap search` command.
+Whenever a pcap is imported into Brim, the app takes the following steps:
 
-If Brim is running, you can perform these `load` operations from your shell,
+1. `brimcap analyze` is invoked to generate logs from the pcap.
+
+2. The logs are imported into a newly-created
+   [Pool in the Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
+   behind Brim, similar to how `zapi create` and `zapi load` are used.
+
+3. `brimcap index` is invoked to populate a local pcap index that allows for
+   quick extraction of flows via Brim's **Packets** button, which the app
+   performs by executing a `brimcap search` command.
+
+If Brim is running, you can perform these same  operations from your shell,
 which may prove useful for automation or batch import of many pcaps to the same
 Pool. The [Custom Brimcap Config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config)
 article shows example command lines along with other advanced configuration

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -176,7 +176,7 @@ section for more details). Additional per-analyzer options can be used to
 determine which generated logs are loaded and what additional processing is
 performed on them.
 
-In our example config, the first analyzer invoked by Brimcap is a wrapper
+In our example configuration, the first analyzer invoked by Brimcap is a wrapper
 script as referenced in the YAML. In addition to reading from its standard input, it also
 tells Zeek to ignore checksums (since these are often set incorrectly on pcaps)
 and disables a couple of the excess log outputs. This is very similar to

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -120,10 +120,10 @@ wrapper scripts are copied to `/usr/local/bin`, the configuration can be tested
 outside the app to import a `sample.pcap` like so:
 
 ```
-$ export ZDEPS="/opt/Brim/resources/app.asar.unpacked/zdeps"
-$ $ZDEPS/zed api create -p testpool
-$ $ZDEPS/brimcap analyze -config zeek-suricata.yml sample.pcap | $ZDEPS/zed api load -p testpool -
-$ $ZDEPS/brimcap index -root "$HOME/.config/Brim/data/brimcap-root" -r sample.pcap
+$ export PATH="/opt/Brim/resources/app.asar.unpacked/zdeps:$PATH"
+$ zed api create -p testpool
+$ brimcap analyze -config zeek-suricata.yml sample.pcap | zed api load -p testpool -
+$ brimcap index -root "$HOME/.config/Brim/data/brimcap-root" -r sample.pcap
 ```
 
 > **Note**: The `zdeps` directory that contains the `zed` and `brimcap`
@@ -447,9 +447,9 @@ Putting it all together, we can test it by using our command combination to
 create a new pool and import the data for a sample pcap.
 
 ```
-$ export ZDEPS="/opt/Brim/resources/app.asar.unpacked/zdeps"
-$ $ZDEPS/zed api create -p testpool2
-$ $ZDEPS/brimcap analyze -config nfdump.yml sample.pcap | $ZDEPS/zed api load -p testpool2 -
+$ export PATH="/opt/Brim/resources/app.asar.unpacked/zdeps:$PATH"
+$ zed api create -p testpool2
+$ brimcap analyze -config nfdump.yml sample.pcap | zed api load -p testpool2 -
 ```
 
 Our pool is now ready to be queried in Brim.

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -179,7 +179,7 @@ performed on them.
 In our example config, the first analyzer invoked by Brimcap is a wrapper
 script as referenced in the YAML. In addition to taking input on stdin, it also
 sets Zeek to ignore checksums (since these are often set incorrectly on pcaps)
-and we also disable a couple of the excess log outputs. This is very similar to
+and disables a couple of the excess log outputs. This is very similar to
 the Zeek Runner script that was included with Brim `v0.24.0`.
 
 ```

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -177,7 +177,7 @@ determine which generated logs are loaded and what additional processing is
 performed on them.
 
 In our example config, the first analyzer invoked by Brimcap is a wrapper
-script as referenced in the YAML. In addition to taking input on stdin, it also
+script as referenced in the YAML. In addition to reading from its standard input, it also
 tells Zeek to ignore checksums (since these are often set incorrectly on pcaps)
 and disables a couple of the excess log outputs. This is very similar to
 the Zeek Runner script that was included with Brim `v0.24.0`.

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -162,13 +162,10 @@ analyzers:
 To be invoked successfully by Brimcap, an analyzer process should have the
 following characteristics:
 
-1. It expects pcap input to be streamed to it via standard input (stdin).
-2. It is assumed that if stdin is closed on a process launched by the analyzer,
-that process will exit.
-3. The analyzer process must ensure that all processes that have inherited
-stdout/stderr have been killed before the analyzer process exits.
-4. It's expected to output log files that can be further processed as soon as
-lines are appended to them (i.e. `tail` could process them).
+1. It reads one pcap from its standard input (stdin).
+2. It exits after its standard input is closed.
+3. It terminates any descendant processes when it exits.
+4. It writes to log outputs only by appending.
 
 By default, an analyzer's log outputs accumulate in a temporary directory
 that's automatically deleted when Brimcap exits (see the [Debug](#debug)

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -173,7 +173,7 @@ lines are appended to them (i.e. `tail` could process them).
 By default, an analyzer's log outputs accumulate in a temporary directory
 that's automatically deleted when Brimcap exits (see the [Debug](#debug)
 section for more details). Additional per-analyzer options can be used to
-determine which generated logs are loaded and what additional processing is
+specify which output logs are loaded and what additional processing is
 performed on them.
 
 In our example configuration, the first analyzer invoked by Brimcap is a wrapper

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -193,7 +193,7 @@ exec /opt/zeek/bin/zeek -C -r - --exec "event zeek_init() { Log::disable_stream(
 > scripts referenced in your YAML (e.g. `/usr/local/bin/zeek-wrapper.sh`) and
 > in your wrapper scripts (e.g. `/opt/zeek/bin`) since Brim may not have the
 > benefit of the same `$PATH` setting as your interactive shell when it invokes
-> `brimcap analyze` with your custom config.
+> `brimcap analyze` with your custom configuration.
 
 We use a similar wrapper for Suricata.
 

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -178,7 +178,7 @@ performed on them.
 
 In our example config, the first analyzer invoked by Brimcap is a wrapper
 script as referenced in the YAML. In addition to taking input on stdin, it also
-sets Zeek to ignore checksums (since these are often set incorrectly on pcaps)
+tells Zeek to ignore checksums (since these are often set incorrectly on pcaps)
 and disables a couple of the excess log outputs. This is very similar to
 the Zeek Runner script that was included with Brim `v0.24.0`.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -29,7 +29,7 @@ detail.
 To start debugging such problems, it helps to understand how Brim opens flows
 extracted from pcaps. Once the [5-tuple](https://www.napatech.com/what-is-a-flow/), connection start time, and connection
 duration are isolated from the Zeek `conn` record for the flow, Brim
-executes a `brimcap search` command to extract the packets for the target flow
+invokes `brimcap search` to extract the packets for the target flow
 into a temporary file. Once this temporary file has been written to the local
 filesystem, the application on your operating system that's configured to
 automatically open files ending in `.pcap` will be launched to open this file.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -29,7 +29,7 @@ detail.
 To start debugging such problems, it helps to understand how Brim opens flows
 extracted from pcaps. Once the [5-tuple](https://www.napatech.com/what-is-a-flow/), connection start time, and connection
 duration are isolated from the Zeek `conn` record for the flow, Brim
-executes a `brimcap load` command to extract the packets for the target flow
+executes a `brimcap search` command to extract the packets for the target flow
 into a temporary file. Once this temporary file has been written to the local
 filesystem, the application on your operating system that's configured to
 automatically open files ending in `.pcap` will be launched to open this file.
@@ -99,9 +99,10 @@ regardless of how long the flow lasts.
 To similarly attempt to isolate flows, Brim relies on Zeek's `conn` event,
 which includes the `id` and `proto` fields that capture the 5-tuple for a
 flow, along with the fields for `ts` (time of first packet) and `duration`
-(how long the connection lasted). Brim uses these values to construct a`brimcap load` command line to extract the flow from the indexed pcap file. However,
-this is where Zeek's occasionally different perception of flows may come into
-play.
+(how long the connection lasted). Brim uses these values to construct a
+`brimcap search` command line to extract the flow from the indexed pcap file.
+However, this is where Zeek's occasionally different perception of flows may
+come into play.
 
 For starters, Zeek's [`conn` documentation](https://docs.zeek.org/en/current/scripts/base/protocols/conn/main.zeek.html#type-Conn::Info)
 discloses that the time span covered by the `duration` field "will not include the final ACK [...] for 3-way or 4-way [TCP] connection tear-downs". Therefore


### PR DESCRIPTION
This PR is part of the non-code coverage for #113.

Since the "a la carte" use of `brimcap analyze` and `brimcap index` already exists but just aren't used by the app yet, it was feasible for me to test and prep these updates in advance. Since it's written as if describing the current known behaviors of Brim, my intent is to hold off on merging this until we deliver the code changes expected in brimdata/brim#1716.

While I was in there, I corrected a couple other errors I spotted in the wiki articles and also added a couple analyzer caveats that @mattnibs recently shared with me. I adjusted the wording in a couple spots, so I'll add PR comments to highlight those and make sure they're confirmed before we commit.