### PR TITLE
Purge brimcap load from help text, and fix links

### DIFF
--- a/cmd/brimcap/root/command.go
+++ b/cmd/brimcap/root/command.go
@@ -28,13 +28,11 @@ to Zeek and Suricata) and emits the generated logs from these processes. Brimcap
 is built on top of the flexible Zed system (https://github.com/brimdata/zed),
 so the logs can be written into a variety of structured log formats.
 
-For those familiar with zq (https://github.com/brimdata/zed/tree/main/cmd/zed#zq),
-logs can written as ZNG or ZSON, then use zq to efficiently search through
-them. Logs of these same formats could also be loaded into a Zed lake
-(https://github.com/brimdata/zed/blob/main/docs/lake/design.md) using
-zapi (https://github.com/brimdata/zed/tree/main/cmd/zed#zapi), which allows
-for viewing the logs in the rich GUI of the Brim desktop app
-(https://github.com/brimdata/brim).
+Logs written as ZNG or ZSON can be searched with
+zq (https://github.com/brimdata/zed/tree/main/cmd/zed#zq) or loaded into a
+Zed lake (https://github.com/brimdata/zed/blob/main/docs/lake/design.md)
+using zapi (https://github.com/brimdata/zed/tree/main/cmd/zed#zapi) for
+viewing in the Brim desktop app (https://github.com/brimdata/brim).
 
 Additionally logs can also be written as ndjson and then operated on using jq
 (https://stedolan.github.io/jq/).

--- a/cmd/brimcap/root/command.go
+++ b/cmd/brimcap/root/command.go
@@ -39,8 +39,8 @@ for viewing the logs in the rich GUI of the Brim desktop app
 Additionally logs can also be written as ndjson and then operated on using jq
 (https://stedolan.github.io/jq/).
 
-The brimcap index can be used to index pcap files, then the index can be
-efficiently searched via brimcap search, such as for flow extraction.
+The brimcap index command can be used to index pcap files for
+flow extraction via the brimcap search command.
 `,
 	New: New,
 }

--- a/cmd/brimcap/root/command.go
+++ b/cmd/brimcap/root/command.go
@@ -28,16 +28,19 @@ to Zeek and Suricata) and emits the generated logs from these processes. Brimcap
 is built on top of the flexible Zed system (https://github.com/brimdata/zed),
 so the logs can be written into a variety of structured log formats.
 
-For those familiar with zq (https://github.com/brimdata/zed/cmd/zq), logs can
-written as ZNG or ZSON, then use zq to efficiently search through them.
+For those familiar with zq (https://github.com/brimdata/zed/tree/main/cmd/zed#zq),
+logs can written as ZNG or ZSON, then use zq to efficiently search through
+them. Logs of these same formats could also be loaded into a Zed lake
+(https://github.com/brimdata/zed/blob/main/docs/lake/design.md) using
+zapi (https://github.com/brimdata/zed/tree/main/cmd/zed#zapi), which allows
+for viewing the logs in the rich GUI of the Brim desktop app
+(https://github.com/brimdata/brim).
+
 Additionally logs can also be written as ndjson and then operated on using jq
 (https://stedolan.github.io/jq/).
 
-The brimcap load command can be used to write logs into the Brim desktop app 
-(https://github.com/brimdata/brim) for viewing logs in a rich GUI.
-
-The brimcap index can be used to index pcap files then efficiently searched
-through using brimcap search.
+The brimcap index can be used to index pcap files, then the index can be
+efficiently searched via brimcap search, such as for flow extraction.
 `,
 	New: New,
 }


### PR DESCRIPTION
It looks like the tip from [https://github.com/brimdata/brimcap/pull/117#pullrequestreview-701368670](https://github.com/brimdata/brimcap/pull/117#pullrequestreview-701368670) got missed, so I've taken my stab at adjusting the help text. There were some links that needed adjusting also.