### PR TITLE
Adjust output defaults

### DIFF
--- a/cmd/brimcap/analyze/command.go
+++ b/cmd/brimcap/analyze/command.go
@@ -60,12 +60,6 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	return c, nil
 }
 
-// json:
-// - always display stats in stderr (except if -nostats is enabled)
-// status line display stats iff:
-// - -o is a file: display stats
-// - -o is stdout and stdout is NOT a terminal: display stats
-
 func (c *Command) Run(args []string) (err error) {
 	if len(args) != 1 {
 		return errors.New("expected 1 pcapfile arg")
@@ -92,6 +86,11 @@ func (c *Command) Run(args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	// json:
+	// - always display stats (except if -nostats is enabled)
+	// status line display stats iff:
+	// - -o is a file: display stats
+	// - -o is stdout and stdout is NOT a terminal: display stats
 	if root.LogJSON {
 		c.Display = analyzecli.JSONDisplay(!c.nostats, info.Size(), nano.Span{})
 	} else {

--- a/cmd/brimcap/analyze/command.go
+++ b/cmd/brimcap/analyze/command.go
@@ -3,6 +3,7 @@ package analyze
 import (
 	"errors"
 	"flag"
+	"os"
 	"time"
 
 	"github.com/brimdata/brimcap/analyzer"
@@ -13,6 +14,7 @@ import (
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
+	"golang.org/x/term"
 )
 
 var Analyze = &charm.Spec{
@@ -46,6 +48,7 @@ type Command struct {
 	*root.Command
 	analyzecli.Display
 	analyzeflags analyzecli.Flags
+	nostats      bool
 	out          outputflags.Flags
 }
 
@@ -53,8 +56,15 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	c.analyzeflags.SetFlags(f)
 	c.out.SetFlags(f)
+	f.BoolVar(&c.nostats, "nostats", false, "do not display stats in stderr")
 	return c, nil
 }
+
+// json:
+// - always display stats in stderr (except if -nostats is enabled)
+// status line display stats iff:
+// - -o is a file: display stats
+// - -o is stdout and stdout is NOT a terminal: display stats
 
 func (c *Command) Run(args []string) (err error) {
 	if len(args) != 1 {
@@ -82,7 +92,13 @@ func (c *Command) Run(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	c.Display = analyzecli.NewDisplay(root.LogJSON, info.Size(), nano.Span{})
+	if root.LogJSON {
+		c.Display = analyzecli.JSONDisplay(!c.nostats, info.Size(), nano.Span{})
+	} else {
+		tofile := c.out.FileName() != ""
+		stats := !c.nostats && (tofile || !term.IsTerminal(int(os.Stdout.Fd())))
+		c.Display = analyzecli.StatusLineDisplay(stats, info.Size(), nano.Span{})
+	}
 	defer c.Display.End()
 	configs := c.analyzeflags.Configs
 	return analyzer.Run(ctx, pcapfile, emitter, c, time.Second, configs...)

--- a/cmd/brimcap/analyze/command.go
+++ b/cmd/brimcap/analyze/command.go
@@ -56,7 +56,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	c.analyzeflags.SetFlags(f)
 	c.out.SetFlags(f)
-	f.BoolVar(&c.nostats, "nostats", false, "do not display stats in stderr")
+	f.BoolVar(&c.nostats, "nostats", false, "do not write stats to stderr")
 	return c, nil
 }
 

--- a/cmd/brimcap/root/command.go
+++ b/cmd/brimcap/root/command.go
@@ -53,7 +53,9 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{}
 	c.cli.SetFlags(f)
-	isterm := term.IsTerminal(int(os.Stdout.Fd()))
+	isterm := term.IsTerminal(int(os.Stdout.Fd())) ||
+		term.IsTerminal(int(os.Stdin.Fd())) ||
+		term.IsTerminal(int(os.Stderr.Fd()))
 	f.BoolVar(&LogJSON, "json", !isterm, "encode stderr in json")
 	return c, nil
 }

--- a/cmd/brimcap/root/command.go
+++ b/cmd/brimcap/root/command.go
@@ -53,9 +53,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{}
 	c.cli.SetFlags(f)
-	isterm := term.IsTerminal(int(os.Stdout.Fd())) ||
-		term.IsTerminal(int(os.Stdin.Fd())) ||
-		term.IsTerminal(int(os.Stderr.Fd()))
+	isterm := term.IsTerminal(int(os.Stderr.Fd()))
 	f.BoolVar(&LogJSON, "json", !isterm, "encode stderr in json")
 	return c, nil
 }


### PR DESCRIPTION
Change the heuristic enabling json logging by default: If stdin, stdout and
stderr are all not terminals.

analyze stats output: If pretty status line output is enabled display
stats iff:
- -o is a file: display stats
- -o is stdout and stdout is NOT a terminal: display stats

Closes #118