### PR TITLE
ztail: Warn on bad file

### DIFF
--- a/analyzer/reader.go
+++ b/analyzer/reader.go
@@ -59,12 +59,12 @@ func tailOne(ctx context.Context, zctx *zson.Context, conf Config, warner zio.Wa
 			return nil, nil, err
 		}
 	}
-	tailer, err := ztail.New(zctx, conf.WorkDir, conf.ReaderOpts, conf.Globs...)
+	wrapped := wrappedReader{warner: warner, cmd: conf.Cmd}
+	tailer, err := ztail.New(zctx, conf.WorkDir, conf.ReaderOpts, wrapped, conf.Globs...)
 	if err != nil {
 		return nil, nil, err
 	}
-	wrapped := wrappedReader{reader: tailer, warner: warner, cmd: conf.Cmd}
-	tailer.WarningHandler(wrapped)
+	wrapped.reader = tailer
 	if shaper != nil {
 		wrapped.reader, err = driver.NewReader(ctx, shaper, zctx, tailer)
 		if err != nil {

--- a/analyzer/reader.go
+++ b/analyzer/reader.go
@@ -59,7 +59,7 @@ func tailOne(ctx context.Context, zctx *zson.Context, conf Config, warner zio.Wa
 			return nil, nil, err
 		}
 	}
-	wrapped := wrappedReader{warner: warner, cmd: conf.Cmd}
+	wrapped := wrappedReader{cmd: conf.Cmd, warner: warner}
 	tailer, err := ztail.New(zctx, conf.WorkDir, conf.ReaderOpts, wrapped, conf.Globs...)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/brimcap/ztests/analyze-bad-file.yaml
+++ b/cmd/brimcap/ztests/analyze-bad-file.yaml
@@ -1,0 +1,27 @@
+script: |
+  chmod +x proc.sh
+  mkdir wd; mv proc.sh wd
+  brimcap analyze -config=config.yaml -nostats alerts.pcap > out.zng
+
+inputs:
+  - name: config.yaml
+    data: |
+      analyzers:
+        - cmd: ./proc.sh
+          workdir: wd
+  - name: proc.sh
+    data: |
+      #!/bin/bash
+      cat << EOF > out.json
+      {"msg":1}
+      {"msg":2}
+      {"msg":3}
+      {"msg":4}
+      EOF
+      cat > /dev/null
+  - name: alerts.pcap
+
+outputs:
+  - name: stderr
+    data: |
+      {"type":"warning","warning":"./proc.sh: proc.sh: format detection error\n\ttzng: line 2: bad format\n\tzeek: line 2: bad types/fields definition in zeek header\n\tzjson: line 1: invalid character '#' looking for beginning of value\n\tzson: zson syntax error\n\tzng: zng type ID out of range\n\tcsv: auto-detection not supported\n\tjson: auto-detection not supported\n\tparquet: auto-detection not supported\n\tzst: auto-detection not supported"}

--- a/ztail/ztail_test.go
+++ b/ztail/ztail_test.go
@@ -57,7 +57,7 @@ func (s *tailerTSuite) SetupTest() {
 	s.dir = s.T().TempDir()
 	s.zctx = zson.NewContext()
 	var err error
-	s.dr, err = New(s.zctx, s.dir, anyio.ReaderOpts{Format: "tzng"})
+	s.dr, err = New(s.zctx, s.dir, anyio.ReaderOpts{Format: "tzng"}, nil)
 	s.Require().NoError(err)
 }
 
@@ -88,18 +88,6 @@ func (s *tailerTSuite) TestExistingFiles() {
 	s.write(f1, f2)
 	s.Require().NoError(<-errCh)
 	s.Equal(expected, <-result)
-}
-
-func (s *tailerTSuite) TestInvalidFile() {
-	_, errCh := s.read()
-	f1 := s.createFile("test1.tzng")
-	_, err := f1.WriteString("#0:record[ts:time]\n")
-	s.Require().NoError(err)
-	_, err = f1.WriteString("this is an invalid line\n")
-	s.Require().NoError(err)
-	s.Require().NoError(f1.Sync())
-	s.EqualError(<-errCh, "line 2: bad format")
-	s.NoError(s.dr.Stop())
 }
 
 func (s *tailerTSuite) TestEmptyFile() {


### PR DESCRIPTION
Previous ztail would error out if it encountered a file whose contents
anyio.Reader does not recognize. Instead have it issue a warning and
ignore the file.

Closes #119