### PR TITLE
Changelog for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.0.1
+* Fix an issue where stale packet index entries could cause a failure to extract a flow from another pcap (#128)
+
 ## v1.0.0
 * Include the name of the analyzer process with any warnings & errors it generates (#122)
 * Adjust defaults for whether logging during analysis is output as JSON vs. status line (#123)


### PR DESCRIPTION
In the recent Brim beta refresh, I forgot to point at the latest Brimcap to take advantage of this bug fix (oops!) I'm seeking to rectify this by tagging a new release I'll point to in the _next_ Brim beta refresh.