### PR TITLE
Fix "Custom Brimcap Config" wiki article after brimcap/148 and Zed branch changes

### DIFF
--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -152,7 +152,9 @@ In examining the example Brimcap YAML, we see at the top that we've defined two
 $ cat zeek-suricata.yml
 analyzers:
   - cmd: /usr/local/bin/zeek-wrapper.sh
+    name: zeek
   - cmd: /usr/local/bin/suricata-wrapper.sh
+    name: suricata
 ```
 
 To be invoked successfully by Brimcap, an analyzer process should have the
@@ -378,6 +380,7 @@ richer data types.
 $ cat nfdump.yml 
 analyzers:
   - cmd: /usr/local/bin/nfdump-wrapper.sh
+    name: nfdump
     globs: ["*.zng"]
     shaper: |
       type netflow = {

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -441,8 +441,9 @@ create a new pool and import the data for a sample pcap.
 
 ```
 $ export PATH="/opt/Brim/resources/app.asar.unpacked/zdeps:$PATH"
-$ zed api create -p testpool2
-$ brimcap analyze -config nfdump.yml sample.pcap | zed api load -p testpool2 -
+$ zed api create testpool2
+$ zed api use -p testpool2
+$ brimcap analyze -config nfdump.yml sample.pcap | zed api load -
 ```
 
 Our pool is now ready to be queried in Brim.
@@ -465,8 +466,10 @@ Zeek/Suricata like this:
 ```
 analyzers:
   - cmd: /usr/local/bin/zeek-wrapper.sh
+    name: zeek
     workdir: /tmp/zeek-wd
   - cmd: /usr/local/bin/suricata-wrapper.sh
+    name: suricata
     workdir: /tmp/suricata-wd
 ...
 ```

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -121,8 +121,9 @@ outside the app to import a `sample.pcap` like so:
 
 ```
 $ export PATH="/opt/Brim/resources/app.asar.unpacked/zdeps:$PATH"
-$ zed api create -p testpool
-$ brimcap analyze -config zeek-suricata.yml sample.pcap | zed api load -p testpool -
+$ zed api create testpool
+$ zed api use -p testpool
+$ brimcap analyze -config zeek-suricata.yml sample.pcap | zed api load -
 $ brimcap index -root "$HOME/.config/Brim/data/brimcap-root" -r sample.pcap
 ```
 

--- a/examples/nfdump.yml
+++ b/examples/nfdump.yml
@@ -1,5 +1,6 @@
 analyzers:
   - cmd: /usr/local/bin/nfdump-wrapper.sh
+    name: nfdump
     globs: ["*.zng"]
     shaper: |
       type netflow = {

--- a/examples/zeek-suricata.yml
+++ b/examples/zeek-suricata.yml
@@ -1,4 +1,3 @@
-root: $HOME/.config/Brim/data/brimcap-root
 analyzers:
   - cmd: /usr/local/bin/zeek-wrapper.sh
     name: zeek

--- a/examples/zeek-suricata.yml
+++ b/examples/zeek-suricata.yml
@@ -1,3 +1,4 @@
+root: $HOME/.config/Brim/data/brimcap-root
 analyzers:
   - cmd: /usr/local/bin/zeek-wrapper.sh
     name: zeek

--- a/examples/zeek-suricata.yml
+++ b/examples/zeek-suricata.yml
@@ -1,6 +1,8 @@
 analyzers:
   - cmd: /usr/local/bin/zeek-wrapper.sh
+    name: zeek
   - cmd: /usr/local/bin/suricata-wrapper.sh
+    name: suricata
     globs: ["eve.json"]
     shaper: |
       type port=uint16;


### PR DESCRIPTION
Recent changes on both the Brimcap and Zed sides have made the text of this article inaccurate. I've made changes here to make everything current and tested it on a scratch Linux VM. I'd like to get this merged before pushing the next beta Brim release so that way users can safely continue to follow the article.

I actually had to stop short of incorporating the last of the #148 changes I was interested in, as the lack of env var expansion cited in #151 makes it difficult to show the new `root:` setting in the example YAML in a portable way. However, this is not a showstopper, as it reads fine continuing to use the `-root` option at the shell for now.