### PR TITLE
Update domain name references

### DIFF
--- a/.github/workflows/advance-zed.yaml
+++ b/.github/workflows/advance-zed.yaml
@@ -33,7 +33,7 @@ jobs:
           # that caused it to wait, reducing push failures down below.
           ref: ${{ github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
-      - run: git config --local user.email 'automation@brimsecurity.com'
+      - run: git config --local user.email 'automation@brimdata.io'
       - run: git config --local user.name 'Brim Automation'
 
       # This section gets event information.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
           ref: main
-      - run: git config --local user.email 'automation@brimsecurity.com'
+      - run: git config --local user.email 'automation@brimdata.io'
       - run: git config --local user.name 'Brim Automation'
       - name: Commit and push change
         run: |
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git config --local user.email 'automation@brimsecurity.com'
+      - run: git config --local user.email 'automation@brimdata.io'
       - run: git config --local user.name 'Brim Automation'
       - name: Create Pull Request for Manual Inspection
         uses: peter-evans/create-pull-request@v3.8.2

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Please browse the [wiki](https://github.com/brimdata/brimcap/wiki) to review com
 
 ## Join the Community
 
-Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!
+Join our [Public Slack](https://www.brimdata.io/join-slack/) workspace for announcements, Q&A, and to trade tips!
 
 [ci-img]: https://github.com/brimdata/brimcap/actions/workflows/ci.yaml/badge.svg
 [ci]: https://github.com/brimdata/brimcap/actions/workflows/ci.yaml

--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -322,7 +322,7 @@ via Brimcap, the **Packets** button in Brim is not currently wired to extract
 flows from a pcap via the 5-tuple and time details in NetFlow records. If this
 is functionality you're interested in pursuing, please
 [open an issue](https://github.com/brimdata/brimcap/wiki/Troubleshooting#opening-an-issue)
-or come talk to us on [public Slack](https://www.brimsecurity.com/join-slack/).
+or come talk to us on [public Slack](https://www.brimdata.io/join-slack/).
 
 ## Base nfdump Installation
 
@@ -519,6 +519,6 @@ total 97912
 If you're running custom Brimcap configurations, we'd like to hear from you!
 Whether you've perfected a custom combination of analyzers that you think other
 Brim users will find useful, or (especially) if you hit challenges and need
-help, please join our [public Slack](https://www.brimsecurity.com/join-slack/)
+help, please join our [public Slack](https://www.brimdata.io/join-slack/)
 and tell us about it, or [open an issue](https://github.com/brimdata/brimcap/wiki/Troubleshooting#opening-an-issue).
 Thanks!

--- a/docs/Geolocation.md
+++ b/docs/Geolocation.md
@@ -48,4 +48,4 @@ links to review these issues and click :+1: below the description on any of
 these features you'd like to see added. If you have additional feedback or
 ideas on this functionality, feel free to add a comment to the issues, or join
 our
-[public Slack](https://www.brimsecurity.com/join-slack/) and talk to us. Thanks!
+[public Slack](https://www.brimdata.io/join-slack/) and talk to us. Thanks!

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -130,7 +130,7 @@ differences:
 |[zeek/1163](https://github.com/zeek/zeek/issues/1163)|Full precision of nanosecond timestamps is not preserved|
 
 If you find yourself running into these issues or others of a similar nature,
-please reach out to us on our [public Slack](https://www.brimsecurity.com/join-slack/)
+please reach out to us on our [public Slack](https://www.brimdata.io/join-slack/)
 or [open an issue](#opening-an-issue) and we'll try to help.
 
 # Gathering Info
@@ -145,7 +145,7 @@ For all information described in this section, we understand that some of it
 may be of a sensitive nature such that you don't feel you can attach it
 directly to a public GitHub Issue. If you can crop, blur, or otherwise modify
 the information before attaching, please do. If you feel you could share such
-information only privately, please notify us on [public Slack](https://www.brimsecurity.com/join-slack/)
+information only privately, please notify us on [public Slack](https://www.brimdata.io/join-slack/)
 and we can arrange to receive it from you in a private 1-on-1 chat.
 
 ## Screenshots/Videos
@@ -176,7 +176,7 @@ you can help us out by doing the following:
 
 * Browse the existing [open issues](https://github.com/brimdata/brimcap/issues?q=is%3Aissue+is%3Aopen). If you confirm you're hitting one of those, please add a comment to it rather than opening a new issue.
 * [Gather info](#gathering-info) that that may help in reproducing the issue and testing a fix, and attach it to your issue.
-* Feel free to chat with the team on the [public Slack](https://www.brimsecurity.com/join-slack/) before/after opening an issue.
+* Feel free to chat with the team on the [public Slack](https://www.brimdata.io/join-slack/) before/after opening an issue.
 * When you open a new issue, its initial text will include a template with standard info that will almost always be needed. Please include detail for all areas of the template.
 
 Thanks for helping us support the Brim community!

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,1 +1,1 @@
-Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!
+Join our [Public Slack](https://www.brimdata.io/join-slack/) workspace for announcements, Q&A, and to trade tips!


### PR DESCRIPTION
Now that brimdata.io is our primary domain for both email and the web site, here's updates to the references in the repo to point to the new.