### PR TITLE
Package update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build/dist"
   ],
   "scripts": {
-    "prepack": "make build"
+    "prepare": "make build"
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "brimcap",
+  "version": "1.1.2",
   "files": [
     "build/dist"
   ],


### PR DESCRIPTION
The prepack command stopped working when I upgrade npm from version 6 to 7. Changing it to a prepare script works in both 6 and 7.