### PR TITLE
Windows too

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "brimcap",
   "version": "1.1.2",
   "files": [
-    "./build/dist/brimcap",
-    "./build/dist/brimcap.exe"
+    "./build/dist/*"
   ],
   "publishConfig": {
     "executableFiles": [

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "brimcap",
   "version": "1.1.2",
   "files": [
-    "./build/dist/brimcap"
+    "./build/dist/brimcap",
+    "./build/dist/brimcap.exe"
   ],
   "publishConfig": {
     "executableFiles": [
-      "./build/dist/brimcap"
+      "./build/dist/brimcap",
+      "./build/dist/brimcap.exe"
     ]
   },
   "scripts": {


### PR DESCRIPTION
We need to add the windows versions of the executables as well.

There may be a better way to do this with a node script that checks the environment and picks the proper binary. But this is the quick fix.