### PR TITLE
Point link in wiki article to new Zed docs site

### DIFF
--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -283,7 +283,7 @@ A full description of all that's possible with shapers is beyond
 the scope of this article. However, this script is quite simple and can
 be described in brief.
 
-1. The `type alert` defines the names, [data types](https://github.com/brimdata/zed/blob/main/docs/formats/zed.md#1-primitive-types),
+1. The `type alert` defines the names, [data types](https://zed.brimdata.io/docs/formats/zed/#1-primitive-types),
 and hierarchical locations of expected fields in the input records. Here we've
 defined a single "wide" shape for _all_ alerts we've known Suricata to
 generate, which is convenient because it allows Brim to easily display them in


### PR DESCRIPTION
In addition to the fixes in #235 that make the markdown link checker happy, I found this link in one of the wiki articles that's better pointing at the new Zed docs site.