### PR TITLE
Point to Suricata artifact v5.0.3-brim4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ARCH = amd64
 VERSION = $(shell git describe --tags --dirty --always)
 LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
-SURICATATAG = v5.0.3-brim3
+SURICATATAG = v5.0.3-brim4
 SURICATAPATH = suricata-$(SURICATATAG)
 ZEEKTAG = v3.2.1-brim10
 ZEEKPATH = zeek-$(ZEEKTAG)


### PR DESCRIPTION
This starts us using a Suricata artifact built on the `macos-11` Actions runner, per https://github.com/brimdata/build-suricata/pull/66. I don't expect functional changes from this. I just figure we might as well start getting off artifacts from the deprecated runners, since it'll help establish baseline stability in the event we do need to push builds with fixes in the future.