### PR TITLE
Add additional Suricata queries to library

### DIFF
--- a/queries.json
+++ b/queries.json
@@ -59,7 +59,7 @@
     {
       "name": "Suricata Alert Categories by Source and Destination",
       "value": "event_type==\"alert\" | alerts := union(alert.category) by src_ip, dest_ip",
-      "description": "Shows categories of all Suricata alerts in a list, grouped by unique source and destination IP addresses"
+      "description": "Shows a list of Suricata alert categories, grouped by unique source and destination IP addresses"
     },
     {
       "name": "Suricata Alert Signatures by Source and Destination",

--- a/queries.json
+++ b/queries.json
@@ -47,7 +47,7 @@
       "description": "Enumerates the classful networks for all destination IP addresses including count of connections"
     },
     {
-      "name": "Suricata Alerts by Severity & Category",
+      "name": "Suricata Alerts by Severity and Category",
       "value": "event_type==\"alert\" | count() by alert.severity,alert.category | sort count",
       "description": "Shows all Suricata alert counts, grouped by category and severity"
     },

--- a/queries.json
+++ b/queries.json
@@ -64,7 +64,7 @@
     {
       "name": "Suricata Alert Signatures by Source and Destination",
       "value": "event_type==\"alert\" | alerts := union(alert.signature) by src_ip, dest_ip",
-      "description": "Shows signatures of all Suricata alerts in a list, grouped by unique source and destination IP addresses"
+      "description": "Shows a list of Suricata alert signatures, grouped by unique source and destination IP addresses"
     },
     {
       "name": "Suricata Alert Categories by Subnet",

--- a/queries.json
+++ b/queries.json
@@ -47,19 +47,34 @@
       "description": "Enumerates the classful networks for all destination IP addresses including count of connections"
     },
     {
-      "name": "Suricata Alerts by Category",
+      "name": "Suricata Alerts by Severity & Category",
       "value": "event_type==\"alert\" | count() by alert.severity,alert.category | sort count",
-      "description": "Shows all Suricata alert counts by category and severity"
+      "description": "Shows all Suricata alert counts, grouped by category and severity"
     },
     {
-      "name": "Suricata Alerts by Source and Destination",
+      "name": "Suricata Alerts by Signature",
+      "value": "event_type==\"alert\" | count() by alert.signature | sort count",
+      "description": "Shows all Suricata alert counts, grouped by signature"
+    },
+    {
+      "name": "Suricata Alert Categories by Source and Destination",
       "value": "event_type==\"alert\" | alerts := union(alert.category) by src_ip, dest_ip",
-      "description": "Shows all Suricata alerts in a list by unique source and destination IP addresses"
+      "description": "Shows categories of all Suricata alerts in a list, grouped by unique source and destination IP addresses"
     },
     {
-      "name": "Suricata Alerts by Subnet",
+      "name": "Suricata Alert Signatures by Source and Destination",
+      "value": "event_type==\"alert\" | alerts := union(alert.signature) by src_ip, dest_ip",
+      "description": "Shows signatures of all Suricata alerts in a list, grouped by unique source and destination IP addresses"
+    },
+    {
+      "name": "Suricata Alert Categories by Subnet",
       "value": "event_type==\"alert\" | alerts := union(alert.category) by network_of(dest_ip)",
-      "description": "Displays a list of Suricata alerts by CIDR network"
+      "description": "Shows a list of Suricata alert categories, grouped by CIDR network"
+    },
+    {
+      "name": "Suricata Alert Signatures by Subnet",
+      "value": "event_type==\"alert\" | alerts := union(alert.signature) by network_of(dest_ip)",
+      "description": "Shows a list of Suricata alert signatures, grouped by CIDR network"
     }
   ]
 }


### PR DESCRIPTION
Looking back at the original Slack conversation that motivated #267, there was a decision to be made about whether the community user's input should lead us to replace the existing queries or add new ones. After some thought I chose the "add" option, since if there were quiet users that liked what was there before, they won't be left wondering what happened when they update to the new set.

I cleaned up some wording while I was in there to make the new & old ones make sense next to each other.

Here's example outputs for each query with the common "all.pcap" test data.

![image](https://user-images.githubusercontent.com/5934157/187991378-1a95093b-8ed2-4371-8516-b502f5a0d80d.png)

![image](https://user-images.githubusercontent.com/5934157/187991395-074e53cb-3275-473b-aa6f-84cfaab5ecde.png)

![image](https://user-images.githubusercontent.com/5934157/187991419-d430a3ce-d0ef-4f6f-ae2b-f19546724b98.png)

![image](https://user-images.githubusercontent.com/5934157/187991443-74b42a80-2a5f-4987-abec-b509f6c45fb1.png)

![image](https://user-images.githubusercontent.com/5934157/187991476-e4026a95-bd84-4b34-94d5-564a75620006.png)

![image](https://user-images.githubusercontent.com/5934157/187991495-594bbbbd-03f4-45cb-ab9f-caca0c6c1478.png)

Closes #267