### PR TITLE
Upgrade to actions/checkout@v3 in CI

### DIFF
--- a/.github/workflows/advance-zed.yaml
+++ b/.github/workflows/advance-zed.yaml
@@ -25,7 +25,7 @@ jobs:
 
       # Since we intend to push, we must have a a writable token and
       # minimal git config settings to create commits.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # ref defaults to github.sha, which is fixed at the time a run
           # is triggered. Using github.ref ensures a run that waits in

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
@@ -54,7 +54,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
@@ -74,7 +74,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git config --local user.email 'automation@brimdata.io'
       - run: git config --local user.name 'Brim Automation'
       - name: Create Pull Request for Manual Inspection


### PR DESCRIPTION
v2 is deprecated because it uses Node.js 12, which is no longer supported.

(inspired by https://github.com/brimdata/zed/pull/4185)