### PR TITLE
fix cmd/brimcap/ztests/analyze-combiner-error.yaml flakiness

### DIFF
--- a/cmd/brimcap/ztests/analyze-combiner-error.yaml
+++ b/cmd/brimcap/ztests/analyze-combiner-error.yaml
@@ -1,7 +1,7 @@
 script: |
   chmod +x errorproc.sh sleepy.sh && mkdir wd && mv errorproc.sh sleepy.sh wd
   # We expect the next command to fail.
-  brimcap analyze -config=config.yaml alerts.pcap || true
+  brimcap analyze -config=config.yaml -nostats alerts.pcap || true
 
 inputs:
   - name: alerts.pcap


### PR DESCRIPTION
This test occasionally fails because brimcap sometimes emits a line of stats output before exiting.  Add -nostats to prevent that.

See https://github.com/brimdata/brimcap/actions/runs/3472617729 for an example.