### PR TITLE
Changelog for v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.3.0
+* Update bundled Suricata to allow [use of local rules](https://github.com/brimdata/brimcap/issues/259) (#272, #274)
+
 ## v1.2.0
 * `brimcap search`: parse `-duration` argument as a ZSON duration (#244)
 * `brimcap slice`: parse `-to` and `-from` arguments as an RFC 3339 timestamp (#243)


### PR DESCRIPTION
Since the last tagged Brimcap release, we've only had the single functional change documented here. However, we've not updated the Brimcap pointer in the Brim repo since August of 2022 and I'd prefer to have a GA tagged Brimcap shipped with Zui v1.0.0 for supportability reasons, so here's an updated changelog after which I'd tag a new release and point at it from the app repo.

https://github.com/brimdata/brimcap/compare/v1.2.0...40eafbc