### PR TITLE
check out github.ref in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod


### PR DESCRIPTION
Using github.sha as the ref in the checkout action prevents git from seeing the tag when a pushing a tag triggers the workflow, which in turn causes "brimcap -version" to report a SHA instead of the tag.  Fix by switching to github.ref.