### PR TITLE
bypass branch protection on main in advance-zed.yaml

### DIFF
--- a/.github/workflows/advance-zed.yaml
+++ b/.github/workflows/advance-zed.yaml
@@ -50,6 +50,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.branch }}
+          # Need an admin token to bypass branch protection on main.
+          token: ${{ secrets.PAT_TOKEN }}
       - run: git push origin HEAD:${{ github.ref }}
         if: github.event_name != 'workflow_dispatch'
       - run: git push --delete origin ${{ env.branch }}


### PR DESCRIPTION
Pushing to main fails because of branch protection.  Bypass branch protection by using a personal access token with admin access.