### PR TITLE
Changelog for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.4.0
+* Advance Zed dependency to include recent fixes/enhancements
+
 ## v1.3.0
 * Update bundled Suricata to allow [use of local rules](https://github.com/brimdata/brimcap/issues/259) (#272, #274)
 


### PR DESCRIPTION
I see no functional changes in Brimcap itself since we tagged v1.3.0 just a few weeks ago. However, since Brimcap uses Zed for shaping, there's a chance that a user could try to do some shaping and want to take advantage of some of the things we've already fixed/improved as called out in https://github.com/brimdata/zed/pull/4419. Therefore since we're about to put out the Zui v1.0 release I figure it's worth tagging an up-to-date Brimcap that we could point at, hence an update to the changelog.

https://github.com/brimdata/brimcap/compare/v1.3.0...ef96c35