### PR TITLE
Point to Suricata artifact v5.0.3-brim5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ARCH = amd64
 VERSION = $(shell git describe --tags --dirty --always)
 LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
-SURICATATAG = v5.0.3-brim4
+SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
 ZEEKTAG = v3.2.1-brim10
 ZEEKPATH = zeek-$(ZEEKTAG)


### PR DESCRIPTION
The updated Suricata artifact includes the change from https://github.com/brimdata/build-suricata/pull/69 which fixes https://github.com/brimdata/zui/issues/2715.