### PR TITLE
Add the binary to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "brimcap",
   "version": "1.1.2",
-  "files": [
-    "build/dist/**"
-  ],
   "bin": {
     "brimcap": "build/dist/brimcap"
   },
+  "files": [
+    "build/dist/**"
+  ],
   "scripts": {
     "prepack": "make build",
     "postinstall": "chmod -R +x build/dist"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "files": [
     "build/dist/**"
   ],
+  "bin": {
+    "brimcap": "build/dist/brimcap"
+  },
   "scripts": {
     "prepack": "make build",
     "postinstall": "chmod -R +x build/dist"


### PR DESCRIPTION
This allows us to easily get the full path to the executable by running `yarn bin brimcap`