### PR TITLE
Put event_type before ts in Suricata shaper

### DIFF
--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -195,8 +195,8 @@ further modify it to suit your needs.
     shaper: |
       type port=uint16
       type alert = {
-        timestamp: time,
         event_type: string,
+        timestamp: time,
         src_ip: ip,
         src_port: port,
         dest_ip: ip,

--- a/suricata.zed
+++ b/suricata.zed
@@ -1,7 +1,7 @@
 type port=uint16
 type alert = {
-	timestamp: time,
 	event_type: string,
+	timestamp: time,
 	src_ip: ip,
 	src_port: port,
 	dest_ip: ip,


### PR DESCRIPTION
In the days when the app was called Brim, there were presentation-layer overrides that made sure the leftmost column in the table output always showed the `ts` timestamp followed by `_path` & `event_type` tiles for Zeek & Suricata data in the second column, even though the underlying data had these fields in different orders.

![Brim-v0 31 0](https://user-images.githubusercontent.com/5934157/229185326-4e20be7a-cdf1-477d-a918-cc7c28a8556a.png)

![image](https://user-images.githubusercontent.com/5934157/229186286-665504c5-6d9e-45d3-81f6-68ef3ca909d9.png)

Then a community user recently filed https://github.com/brimdata/zui/issues/2738 because we'd lost the Suricata tiles entirely in Zui. Here's how it looks with them restored after the fix to that issue in https://github.com/brimdata/zui/pull/2740 (Zui commit `f835e04`).

![f835e04](https://user-images.githubusercontent.com/5934157/229185530-ba13f604-db19-4e8e-a38b-dfe6186f9da6.png)

Perhaps the Zui plugin system might at some point in the future have some way to do the kinds of presentation-layer overrides, but for now, the change in this PR just tidies things up a little more by using the Suricata shaper to move its `event_type` field leftward so it more closely aligns with the Zeek records.

![WithChange](https://user-images.githubusercontent.com/5934157/229185871-69321da7-a5b0-4ee3-885e-2df07f8f46f2.png)
