### PR TITLE
Fix ztests on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ ifeq ($(shell go env GOOS),windows)
 	ZIP=7z a
 endif
 
+# CURDIR holds an absolute path that begins with "/" except on Windows, where it
+# begins with a drive letter.
+pathlistsep = $(if $(filter /%,$(CURDIR)),:,;)
+
 # This enables a shortcut to run a single ztest e.g.:
 #  make TEST=TestBrimpcap/cmd/brimcap/ztests/analyze-all
 ifneq "$(TEST)" ""
@@ -70,7 +74,7 @@ vet:
 .PHONY: generate
 generate:
 	@GOBIN="$(CURDIR)/bin" go install github.com/golang/mock/mockgen
-	@PATH="$(CURDIR)/bin:$(PATH)" go generate ./...
+	@PATH="$(CURDIR)/bin$(pathlistsep)$(PATH)" go generate ./...
 
 .PHONY: test
 test:
@@ -78,8 +82,8 @@ test:
 
 .PHONY: ztest-run
 ztest-run: build bin/zq
-	@ZTEST_PATH="$(CURDIR)/build/dist:$(CURDIR)/bin:$(PATH)" go test . -run $(TEST)
+	@ZTEST_PATH="$(CURDIR)/build/dist$(pathlistsep)$(CURDIR)/bin" go test . -run $(TEST)
 
 .PHONY: ztest
 ztest: build bin/zq
-	@ZTEST_PATH="$(CURDIR)/build/dist:$(CURDIR)/bin:$(PATH)" go test .
+	@ZTEST_PATH="$(CURDIR)/build/dist$(pathlistsep)$(CURDIR)/bin" go test .

--- a/analyzer/processes.go
+++ b/analyzer/processes.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 
 	"github.com/brimdata/zed/zio"
 	"golang.org/x/sync/errgroup"
@@ -49,7 +48,7 @@ func runProcesses(ctx context.Context, r io.Reader, confs ...Config) (*operation
 		}
 		// Broken pipe error is a result of a process shutting down. Return nil
 		// here since the process errors are more interesting.
-		if errors.Is(err, syscall.EPIPE) {
+		if errors.Is(err, errPipe) {
 			err = nil
 		}
 		return err

--- a/analyzer/processes_notwindows.go
+++ b/analyzer/processes_notwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package analyzer
+
+import (
+	"syscall"
+)
+
+var errPipe = syscall.EPIPE

--- a/analyzer/processes_windows.go
+++ b/analyzer/processes_windows.go
@@ -1,0 +1,7 @@
+package analyzer
+
+import (
+	"syscall"
+)
+
+var errPipe = syscall.ERROR_BROKEN_PIPE

--- a/cmd/brimcap/ztests/analyze-bad-file.yaml
+++ b/cmd/brimcap/ztests/analyze-bad-file.yaml
@@ -1,5 +1,4 @@
 script: |
-  chmod +x proc.sh
   mkdir wd; mv proc.sh wd
   brimcap analyze -config=config.yaml -nostats alerts.pcap > out.zng
 
@@ -7,12 +6,12 @@ inputs:
   - name: config.yaml
     data: |
       analyzers:
-        - cmd: ./proc.sh
+        - cmd: bash
+          args: [proc.sh]
           name: proc
           workdir: wd
   - name: proc.sh
     data: |
-      #!/bin/bash
       cat << EOF > out.json
       {"msg":1}
       {"msg":2}
@@ -25,4 +24,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      {"type":"warning","warning":"./proc.sh: proc.sh: format detection error\\n\\t.*"}
+      {"type":"warning","warning":"bash: proc.sh: format detection error\\n\\t.*"}

--- a/cmd/brimcap/ztests/analyze-combiner-error.yaml
+++ b/cmd/brimcap/ztests/analyze-combiner-error.yaml
@@ -1,45 +1,46 @@
 script: |
-  chmod +x errorproc.sh sleepy.sh && mkdir wd && mv errorproc.sh sleepy.sh wd
-  # We expect the next command to fail.
-  brimcap analyze -config=config.yaml -nostats alerts.pcap || true
+  mkdir wd && mv errorproc.sh sleepy.sh wd
+  ! brimcap analyze -config=config.yaml -nostats alerts.pcap
 
 inputs:
   - name: alerts.pcap
   - name: config.yaml
     data: |
       analyzers:
-        - cmd: ./errorproc.sh
+        - cmd: bash
+          args: [errorproc.sh]
           name: errorproc1
           globs: ["*.zson"] # so ztail will not try to read *.sh
           stderr: stderr.out
           workdir: wd
-        - cmd: ./sleepy.sh
+        - cmd: bash
+          args: [sleepy.sh]
           name: sleepy1
           globs: ["*.zson"] # so ztail will not try to read *.sh
           workdir: wd
-        - cmd: ./sleepy.sh
+        - cmd: bash
+          args: [sleepy.sh]
           name: sleepy2
           globs: ["*.zson"] # so ztail will not try to read *.sh
           workdir: wd
-        - cmd: ./sleepy.sh
+        - cmd: bash
+          args: [sleepy.sh]
           name: sleepy3
           globs: ["*.zson"] # so ztail will not try to read *.sh
           workdir: wd
   - name: errorproc.sh
     data: |
-      #!/bin/bash
       >&2 echo "some error information in stderr"
       exit 1
   - name: sleepy.sh
     data: |
-      #!/bin/bash
       { sleep 10 && kill $$; } >& /dev/null &
       cat > /dev/null
 
 outputs:
   - name: stderr
-    data: |
-      {"type":"error","error":"errorproc.sh exited with code 1\nstdout: (no output)\nstderr:\nsome error information in stderr\n"}
+    regexp: |
+      {"type":"error","error":"bash(\.exe)? exited with code 1\\nstdout: \(no output\)\\nstderr:\\nsome error information in stderr\\n"}
   - name: stderr.out 
     data: |
       some error information in stderr

--- a/cmd/brimcap/ztests/analyze-json-error.yaml
+++ b/cmd/brimcap/ztests/analyze-json-error.yaml
@@ -5,7 +5,7 @@ script: |
 
 outputs:
   - name: stderr
-    data: |
-      {"type":"error","error":"error loading pcap file: open doesnotexist.pcap: no such file or directory"}
+    regexp: |
+      {"type":"error","error":"error loading pcap file: open doesnotexist.pcap: (no such file or directory|The system cannot find the file specified.)"}
       ===
-      {"type":"error","error":"error loading pcap file: open doesnotexist.pcap: no such file or directory"}
+      {"type":"error","error":"error loading pcap file: open doesnotexist.pcap: (no such file or directory|The system cannot find the file specified.)"}

--- a/cmd/brimcap/ztests/analyze-process-error.yaml
+++ b/cmd/brimcap/ztests/analyze-process-error.yaml
@@ -1,5 +1,5 @@
 script: |
-  chmod +x errorproc.sh && mkdir wd && mv errorproc.sh wd
+  mkdir wd && mv errorproc.sh wd
   ! cat alerts.pcap | brimcap analyze -config=config1.yaml -o /dev/null -
   >&2 echo === 
   ! brimcap analyze -config=config2.yaml -o /dev/null alerts.pcap
@@ -9,30 +9,31 @@ inputs:
   - name: config1.yaml
     data: |
       analyzers:
-        - cmd: ./errorproc.sh
+        - cmd: bash
+          args: [errorproc.sh]
           name: error
           globs: ["*.zson"] # so ztail will not try to read errorproc.sh
           workdir: wd
   - name: config2.yaml
     data: |
       analyzers:
-        - cmd: ./errorproc.sh
+        - cmd: bash
+          args: [errorproc.sh]
           name: error
           globs: ["*.zson"] # so ztail will not try to read errorproc.sh
           stderr: stderr.out
           workdir: wd
   - name: errorproc.sh
     data: |
-      #!/bin/bash
       >&2 echo "some error information in stderr"
       exit 1
 
 outputs:
   - name: stderr
-    data: |
-      {"type":"error","error":"errorproc.sh exited with code 1\nstdout: (no output)\nstderr:\nsome error information in stderr\n"}
+    regexp: |
+      {"type":"error","error":"bash(.exe)? exited with code 1\\nstdout: \(no output\)\\nstderr:\\nsome error information in stderr\\n"}
       ===
-      {"type":"error","error":"errorproc.sh exited with code 1\nstdout: (no output)\nstderr:\nsome error information in stderr\n"}
+      {"type":"error","error":"bash(.exe)? exited with code 1\\nstdout: \(no output\)\\nstderr:\\nsome error information in stderr\\n"}
   - name: stderr.out 
     data: |
       some error information in stderr

--- a/cmd/brimcap/ztests/analyze-reader-error.yaml
+++ b/cmd/brimcap/ztests/analyze-reader-error.yaml
@@ -1,5 +1,4 @@
 script: |
-  chmod +x badoutput.sh success.sh
   mkdir wd1; mv badoutput.sh wd1
   mkdir wd2; mv success.sh wd2
   brimcap analyze -config=config.yaml alerts.pcap > out.zng
@@ -8,17 +7,18 @@ inputs:
   - name: config.yaml
     data: |
       analyzers:
-        - cmd: ./badoutput.sh
+        - cmd: bash
+          args: [badoutput.sh]
           name: bad
           globs: ["*.json"] # so ztail will not try to read *.sh
           workdir: wd1
-        - cmd: ./success.sh
+        - cmd: bash
+          args: [success.sh]
           name: success
           globs: ["*.json"] # so ztail will not try to read *.sh
           workdir: wd2
   - name: badoutput.sh
     data: |
-      #!/bin/bash
       cat << EOF > bad.json
       {"msg":1}
       {"msg":2}
@@ -28,7 +28,6 @@ inputs:
       cat > /dev/null
   - name: success.sh
     data: |
-      #!/bin/bash
       cat << EOF > success.json
       {"msg":1}
       {"msg":2}
@@ -41,5 +40,5 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      \{"type":"warning","warning":"\.\/badoutput.sh: .*bad\.json: parse error: string literal: unescaped line break"\}
+      \{"type":"warning","warning":"bash: .*bad\.json: parse error: string literal: unescaped line break"\}
       \{"type":"status","ts":\{"sec":\d+,"ns":\d+\},"pcap_read_size":737694,"pcap_total_size":737694,"values_written":7\}

--- a/cmd/brimcap/ztests/config-expand-env.yaml
+++ b/cmd/brimcap/ztests/config-expand-env.yaml
@@ -1,5 +1,5 @@
 script: |
-  export MY_ROOT_PATH=/my/root/path
+  export MY_ROOT_PATH=my/root/path
   brimcap config -config=brimcap.config
 
 inputs:
@@ -15,7 +15,7 @@ outputs:
     data: ""
   - name: stdout
     data: |
-      root: /my/root/path
+      root: my/root/path
       analyzers:
         - cmd: test
           name: test

--- a/cmd/brimcap/ztests/config-override.yaml
+++ b/cmd/brimcap/ztests/config-override.yaml
@@ -1,9 +1,9 @@
 script: |
   brimcap config \
     -config=brimcap.config \
-    -root=/path/to/root \
+    -root=path/to/root \
     -analyzers.test.cmd=test123 \
-    -analyzers.test.stderr=/my/special/path
+    -analyzers.test.stderr=my/special/path
 
 inputs:
   - name: brimcap.config
@@ -17,8 +17,8 @@ outputs:
     data: ""
   - name: stdout
     data: |
-      root: /path/to/root
+      root: path/to/root
       analyzers:
         - cmd: test123
           name: test
-          stderr: /my/special/path
+          stderr: my/special/path

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/brimdata/brimcap
 go 1.19
 
 require (
-	github.com/brimdata/zed v1.7.1-0.20230508183918-fb44c5279e31
+	github.com/brimdata/zed v1.7.1-0.20230512193339-21208876b9f5
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/google/gopacket v1.1.19
 	github.com/gosuri/uilive v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/aws/aws-sdk-go v1.36.17/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2z
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f h1:y06x6vGnFYfXUoVMbrcP1Uzpj4JG01eB5vRps9G8agM=
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
-github.com/brimdata/zed v1.7.1-0.20230508183918-fb44c5279e31 h1:QE94NOjLMVrsTro9Aj1CPKIs7XU4C0i+UxhNQb/3MsY=
-github.com/brimdata/zed v1.7.1-0.20230508183918-fb44c5279e31/go.mod h1:c7jaVqFnwcw1E+Hy9UxB7y7GjdVmP7y3p5ZGJCEoWN4=
+github.com/brimdata/zed v1.7.1-0.20230512193339-21208876b9f5 h1:6kQhjaiw3wmCCh23rgysIf+LMWbGyqVgxQxhlD9WHM0=
+github.com/brimdata/zed v1.7.1-0.20230512193339-21208876b9f5/go.mod h1:c7jaVqFnwcw1E+Hy9UxB7y7GjdVmP7y3p5ZGJCEoWN4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/ztest_test.go
+++ b/ztest_test.go
@@ -18,7 +18,7 @@ func TestBrimcap(t *testing.T) {
 	require.NoError(t, err)
 	for d := range dirs {
 		d := d
-		t.Run(d, func(t *testing.T) {
+		t.Run(filepath.ToSlash(d), func(t *testing.T) {
 			t.Parallel()
 			ztest.Run(t, d)
 		})


### PR DESCRIPTION
brimdata/zed#4581 changes the ztest package to run script-style ztests on Windows, but some of the ztests here don't run successfully on Windows.  Fix them by adjusting a few things.

* Upgrade Zed for brimdata/zed#4581 and brimdata/zed#4594.

* In Makefile, use ";" as path list separator on Windows instead of ":".

* In analyzer/processes.go, check for syscall.ERROR_BROKEN_PIPE on Windows instead of syscall.EPIPE.

* In ztests, adjust some outputs and paths and change analyzer commands to invoke Bash directly since Windows doesn't understand shebang lines (i.e., "#!/bin/bash").

* In ztest_test.go, use filepath.ToSlash for test names.  (Not strictly necessary, but it makes running individual tests easier.)