### PR TITLE
Changelog for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.0
+* The Suricata shaper now places the `event_type` to the left of `ts` to improve tile placement in Zui (#308)
+* Advance Zed dependency to include recent fixes/enhancements
+
 ## v1.4.1
 * Update bundled Suricata to [v5.0.3-brim5](https://github.com/brimdata/build-suricata/releases/tag/v5.0.3-brim5), which fixes [zui/2715](https://github.com/brimdata/zui/issues/2715) (#305)
 


### PR DESCRIPTION
Keeping with tradition, this new tagged Brimcap release would make sure that users have access in to the same new Zed functionality in their shapers as will be going out in the accompanying tagged Zed release. Once it's up I'll point Zui at this release as well so everything is in sync.