### PR TITLE
Ignore ERROR_NO_DATA on Windows in analyzer/processes.go

### DIFF
--- a/analyzer/processes.go
+++ b/analyzer/processes.go
@@ -48,7 +48,7 @@ func runProcesses(ctx context.Context, r io.Reader, confs ...Config) (*operation
 		}
 		// Broken pipe error is a result of a process shutting down. Return nil
 		// here since the process errors are more interesting.
-		if errors.Is(err, errPipe) {
+		if isPipe(err) {
 			err = nil
 		}
 		return err

--- a/analyzer/processes_notwindows.go
+++ b/analyzer/processes_notwindows.go
@@ -3,7 +3,10 @@
 package analyzer
 
 import (
+	"errors"
 	"syscall"
 )
 
-var errPipe = syscall.EPIPE
+func isPipe(err error) bool {
+	return errors.Is(err, syscall.EPIPE)
+}

--- a/analyzer/processes_windows.go
+++ b/analyzer/processes_windows.go
@@ -1,7 +1,11 @@
 package analyzer
 
 import (
+	"errors"
 	"syscall"
 )
 
-var errPipe = syscall.ERROR_BROKEN_PIPE
+func isPipe(err error) bool {
+	const ERROR_NO_DATA = syscall.Errno(232)
+	return errors.Is(err, syscall.ERROR_BROKEN_PIPE) || errors.Is(err, ERROR_NO_DATA)
+}


### PR DESCRIPTION
Tests sometimes fail in CI due to this error.  Ignore it since it's no more interesting than ERROR_BROKEN_PIPE.