### PR TITLE
Changelog for v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.5.1
+* Advance Zed dependency to include recent fixes/enhancements
+
 ## v1.5.0
 * The Suricata shaper now places the `event_type` to the left of `ts` to improve tile placement in Zui (#308)
 * Advance Zed dependency to include recent fixes/enhancements


### PR DESCRIPTION
As a step toward putting out a set of releases, here I'm updating the changelog to mark a tagged Brimcap release we could ultimately bundle with Zui. Per [this comment](https://github.com/brimdata/brimcap/pull/311#pullrequestreview-1436995038) from @nwt last time around, since the only changes are to the Zed dependency pointer and not Brimcap's own functionality, I've proposed a point release.

https://github.com/brimdata/brimcap/compare/v1.5.0...5599e08