### PR TITLE
Adjust "bin" section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "brimcap",
   "version": "1.1.2",
-  "bin": {
-    "brimcap": "build/dist/brimcap"
-  },
+  "bin": "build/dist/brimcap",
   "files": [
     "build/dist/**"
   ],


### PR DESCRIPTION
I figured this one out by running `yarn install --inline-builds` on Zui commit `cb746af` and `cd`'ing to the tmp directory it showed for where it cloned the Brimcap repo. By doing `git diff` while it was building I could see the following output:

```
$ git diff
diff --git a/package.json b/package.json
index ae2941c..aabe748 100644
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "brimcap",
   "version": "1.1.2",
-  "bin": {
-    "brimcap": "build/dist/brimcap"
-  },
+  "bin": "build/dist/brimcap",
   "files": [
     "build/dist/**"
   ],
```

So it looks like the changes from #306 to `package.json` are simplified during the build process and that's enough to render the build artifacts as "dirty".

Here's verification that the `-dirty` goes away when using the Brimcap based on this fix branch.

```
$ for COMMIT in 76707da; do   rm -rf ~/.yarn/berry/cache/brimcap* && git clone https://github.com/brimdata/zui.git zui-${COMMIT} && pushd zui-${COMMIT} && git checkout ${COMMIT} && gsed -i 's/brimcap#.*/brimcap#d6a430d85f426a826276b61f56be1ac8c0259666",/' package.json && yarn && node_modules/brimcap/build/dist/brimcap -version; popd; done
...
Version: v1.4.0-26-gd6a430d
```

Sadly, even with this change in place, it looks like `brimcap -version` broke in some other way again with the Monorepo changes in https://github.com/brimdata/zui/pull/2818, but I'm game to fix these problems one layer at a time.

Fixes https://github.com/brimdata/zui/issues/2840