### PR TITLE
Revise README section on "Brimcap Queries"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,16 @@ version should be API-compatible with that version of Zui and its Zed backend.
 
 ## Brimcap Queries
 
-Included in this repo is a [`queries.json`](./queries.json?raw=1) file with some helpful queries for getting
+Included in this repo is a `queries.json` file with some helpful queries for getting
 started and exploring Zeek and Suricata analyzed data within the Zui app.
 
-To import these queries, open the Zui app and select the "QUERIES" tab in the left
-sidebar. Then just drag the `queries.json` file into that sidebar section. It will
-appear as a new query folder named `Brimcap`.
+To import these queries:
+
+1. Download the [`queries.json`](./queries.json?raw=1) file to your local system
+2. In Zui, click the **+** menu in the upper-left corner of the app window and select **Import Queries...**
+3. Open the downloaded file in the file picker utility
+
+The loaded queries will appear in the "QUERIES" tab of Zui's left sidebar as a new folder named `Brimcap`.
 
 ## Standalone Install
 


### PR DESCRIPTION
In a recent [community Slack thread](https://brimdata.slack.com/archives/C010DR0HHMF/p1700490455915979?thread_ts=1699776926.923289&cid=C010DR0HHMF) a user expressed confusion at not being able to follow the section of the Brimcap README for importing the saved queries. Indeed, when I tested this out for myself I realized that the recent [Preview & Load](https://zui.brimdata.io/docs/features/Preview-Load) enhancement has made it such that dragging a queries JSON into the app no longer populates the saved queries list. This experience was a good reminder that I should do a general video walk-through on Saved Queries as a feature. In the meantime, here I'm just proposing a short-term update to the Brimcap README to point users at the way for importing saved queries that still works ok.