### PR TITLE
Reference Settings, not Preferences

### DIFF
--- a/docs/Custom-Brimcap-Config.md
+++ b/docs/Custom-Brimcap-Config.md
@@ -102,7 +102,7 @@ logs and open flows from the pcap via the **Packets** button.
 The same combination of `brimcap` and `zed` commands can be used to
 incrementally add more logs to the same pool and index for additional pcaps.
 
-The setting in the Zui **Preferences** for the **Brimcap YAML Config File**
+The setting in the Zui **Settings** for the **Brimcap YAML Config File**
 can also be pointed at the path to this configuration file, which will cause it
 to be invoked when you open or drag pcap files into Zui.
 
@@ -146,7 +146,7 @@ exec /opt/zeek/bin/zeek -C -r - --exec "event zeek_init() { Log::disable_stream(
 ```
 
 > **Note:** If you intend to point to your custom Brimcap YAML config from
-> Zui **Preferences**, it's important to use full pathnames to the wrapper
+> Zui **Settings**, it's important to use full pathnames to the wrapper
 > scripts referenced in your YAML (e.g. `/usr/local/bin/zeek-wrapper.sh`) and
 > in your wrapper scripts (e.g. `/opt/zeek/bin`) since Zui may not have the
 > benefit of the same `$PATH` setting as your interactive shell when it invokes


### PR DESCRIPTION
There once was a time when Zui's pull-down menu for changing app config was called **Preferences** on macOS and **Settings** on Windows/Linux. This led to it being referenced inconsistently in the docs. Between changes in https://github.com/brimdata/zui/pull/2866 and general macOS trends, we've now standardized on **Settings**, so here I'm fixing this Brimcap doc that still called it by the other.