### PR TITLE
analyzer: Have exited processes read all data

### DIFF
--- a/cmd/brimcap/ztests/analyze-process-readall.yaml
+++ b/cmd/brimcap/ztests/analyze-process-readall.yaml
@@ -1,35 +1,14 @@
 script: |
-  mkdir wd1; mv noread.sh wd1
-  mkdir wd2; mv readall.sh wd2
-  bash gen.sh | brimcap analyze -config=config.yaml - | zq -z 'count()' -
-
+  seq 10000 | brimcap analyze -config=config.yaml - | zq -z 'count()' -
 inputs:
-  - name: alerts.pcap
   - name: config.yaml
     data: |
       analyzers:
-        - cmd: bash
-          args: [noread.sh]
+        - cmd: 'true'
           name: noread
-          globs: ["*.json"] # so ztail will not try to read noread.sh
-          workdir: wd1
         - cmd: bash
-          args: [readall.sh]
+          args: [-c, 'cat > readall.zson']
           name: readall
-          globs: ["*.zson"]
-          workdir: wd2
-  - name: gen.sh
-    data: |
-      for i in {1..10000}; do
-        echo "{x: $i}"
-      done
-  - name: noread.sh
-    data: |
-      exit 0
-  - name: readall.sh
-    data: |
-      cat - > readall.zson
-
 outputs:
   - name: stdout
     data: |

--- a/cmd/brimcap/ztests/analyze-process-readall.yaml
+++ b/cmd/brimcap/ztests/analyze-process-readall.yaml
@@ -1,0 +1,36 @@
+script: |
+  mkdir wd1; mv noread.sh wd1
+  mkdir wd2; mv readall.sh wd2
+  bash gen.sh | brimcap analyze -config=config.yaml - | zq -z 'count()' -
+
+inputs:
+  - name: alerts.pcap
+  - name: config.yaml
+    data: |
+      analyzers:
+        - cmd: bash
+          args: [noread.sh]
+          name: noread
+          globs: ["*.json"] # so ztail will not try to read noread.sh
+          workdir: wd1
+        - cmd: bash
+          args: [readall.sh]
+          name: readall
+          globs: ["*.zson"]
+          workdir: wd2
+  - name: gen.sh
+    data: |
+      for i in {1..10000}; do
+        echo "{x: $i}"
+      done
+  - name: noread.sh
+    data: |
+      exit 0
+  - name: readall.sh
+    data: |
+      cat - > readall.zson
+
+outputs:
+  - name: stdout
+    data: |
+      10000(uint64)


### PR DESCRIPTION
This commit changes the behavior for analyzer processes so that processes that have successfully exited without reading all the data will continue to consume data from the byte stream insteading of returning an error and putting a stop to the copy goroutine.

Closes #331