### PR TITLE
Point to build-zeek artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.2.0-brim-dev2
+ZEEKTAG = v6.0.2-brim3
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v3.2.1-brim10
+ZEEKTAG = v6.0.2-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r
@@ -35,7 +35,7 @@ tidy:
 build/$(ZEEKPATH).zip:
 	@mkdir -p build
 	@curl -L -o $@ \
-		https://github.com/brimdata/zeek/releases/download/$(ZEEKTAG)/zeek-$(ZEEKTAG).$$(go env GOOS)-$(ARCH).zip
+		https://github.com/brimdata/build-zeek/releases/download/$(ZEEKTAG)/zeek-$(ZEEKTAG).$$(go env GOOS)-$(ARCH).zip
 
 build/$(SURICATAPATH).zip:
 	@mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.0.2-brim3
+ZEEKTAG = v6.0.3-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.2.0-brim-dev1
+ZEEKTAG = v6.2.0-brim-dev2
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.0.2-brim1
+ZEEKTAG = v6.0.2-brim2
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.0.2-brim2
+ZEEKTAG = v6.2.0-brim-dev1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r


### PR DESCRIPTION
The new Brimcap artifacts that use Zeek v6 have had over a week of use in tip-of-`main` Zui and Zui Insiders. That helped me spot & fix https://github.com/brimdata/zui/pull/2981, and [one user on community Slack](https://brimdata.slack.com/archives/C03MW6XT7HC/p1705775439374689) did report trying it out in Zui Insiders and reported a problem but they messaged me privately to follow up and it ended up being a repeat of what's fixed in #332. Therefore it feels like it's an appropriate time to just make it official.