### PR TITLE
Import github.com/brimdata/zed/zio.Combiner

### DIFF
--- a/analyzer/combiner.go
+++ b/analyzer/combiner.go
@@ -1,0 +1,89 @@
+package analyzer
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zio"
+)
+
+// A Combiner is a zio.Reader that returns records by reading from multiple Readers.
+type Combiner struct {
+	cancel  context.CancelFunc
+	ctx     context.Context
+	done    []bool
+	once    sync.Once
+	readers []zio.Reader
+	results chan combinerResult
+}
+
+func NewCombiner(ctx context.Context, readers []zio.Reader) *Combiner {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Combiner{
+		cancel:  cancel,
+		ctx:     ctx,
+		done:    make([]bool, len(readers)),
+		readers: readers,
+		results: make(chan combinerResult),
+	}
+}
+
+type combinerResult struct {
+	err error
+	idx int
+	val *zed.Value
+}
+
+func (c *Combiner) run() {
+	for i := range c.readers {
+		idx := i
+		go func() {
+			for {
+				rec, err := c.readers[idx].Read()
+				if rec != nil {
+					// Make a copy since we don't wait for
+					// Combiner.Read's caller to finish with
+					// this value before we read the next.
+					rec = rec.Copy().Ptr()
+				}
+				select {
+				case c.results <- combinerResult{err, idx, rec}:
+					if rec == nil || err != nil {
+						return
+					}
+				case <-c.ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+}
+
+func (c *Combiner) finished() bool {
+	return !slices.Contains(c.done, false)
+}
+
+func (c *Combiner) Read() (*zed.Value, error) {
+	c.once.Do(c.run)
+	for {
+		select {
+		case r := <-c.results:
+			if r.err != nil {
+				c.cancel()
+				return nil, r.err
+			}
+			if r.val != nil {
+				return r.val, nil
+			}
+			c.done[r.idx] = true
+			if c.finished() {
+				c.cancel()
+				return nil, nil
+			}
+		case <-c.ctx.Done():
+			return nil, c.ctx.Err()
+		}
+	}
+}

--- a/analyzer/combiner_test.go
+++ b/analyzer/combiner_test.go
@@ -1,0 +1,56 @@
+package analyzer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zio"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCombiner(t *testing.T) {
+	r1 := &sliceReader{zed.NewInt64(0)}
+	r2 := &sliceReader{zed.NewInt64(1), zed.NewInt64(2)}
+	r3 := &sliceReader{zed.NewInt64(3), zed.NewInt64(4), zed.NewInt64(5)}
+	c := NewCombiner(context.Background(), []zio.Reader{r1, r2, r3})
+	var vs []int64
+	for {
+		val, err := c.Read()
+		require.NoError(t, err)
+		if val == nil {
+			break
+		}
+		vs = append(vs, val.Int())
+	}
+	require.ElementsMatch(t, vs, []int64{0, 1, 2, 3, 4, 5})
+}
+
+func TestCombinerError(t *testing.T) {
+	r1 := &sliceReader{zed.Null}
+	r2 := &errorReader{errors.New("read error")}
+	c := NewCombiner(context.Background(), []zio.Reader{r1, r2})
+	for {
+		val, err := c.Read()
+		if val == nil {
+			require.Error(t, err)
+			return
+		}
+	}
+}
+
+type errorReader struct{ error }
+
+func (e *errorReader) Read() (*zed.Value, error) { return nil, e }
+
+type sliceReader []zed.Value
+
+func (t *sliceReader) Read() (*zed.Value, error) {
+	if len(*t) == 0 {
+		return nil, nil
+	}
+	val := (*t)[0]
+	*t = (*t)[1:]
+	return &val, nil
+}

--- a/analyzer/reader.go
+++ b/analyzer/reader.go
@@ -34,7 +34,7 @@ func newReader(ctx context.Context, warner ztail.Warner, confs ...Config) (*read
 		readers = append(readers, reader)
 	}
 	return &reader{
-		reader:  zio.NewCombiner(ctx, readers),
+		reader:  NewCombiner(ctx, readers),
 		tailers: tailers,
 	}, nil
 }


### PR DESCRIPTION
It's used only in this repository.  Move it here so system tests that exercise it can help us catch bugs caused by refactoring (like the one fixed in brimdata/zed#4712) sooner.