### PR TITLE
Point to Zeek v6.2.0-brim1 artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.0.3-brim1
+ZEEKTAG = v6.2.0-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r


### PR DESCRIPTION
This moves Brimcap (and hence will move Zui) to the latest Zeek for the reasons laid out in https://github.com/brimdata/build-zeek/pull/9.