### PR TITLE
Pin to specific versions of GitHub Actions Runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-12, ubuntu-20.04, windows-2019]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-20.04, windows-2019]
+        os: [macos-12, ubuntu-20.04, windows-2022]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
When attempting to generate a new Brimcap release, I noticed the generated Darwin one was for architecture `arm64` with none for `amd64` as we've always generated in the pass. I could see this happened because in the Actions workflow we've been pointing to the `-latest` revisions of the Runner types, but in the time since our last GA release, GitHub moved the `-latest` pointer forward to `macos-14` which is based on Apple silicon whereas `macos-12` and `macos-13` are still Intel-based.

I've avoided surprises like this in the Zui repo by pointing to explicit versions of the runners and only advancing them forward when those runner versions are deprecated or we have a specific motivation to advance the pointer and do the necessary testing at that time to ensure a smooth transition.

I imagine at some point we may want to take steps to produce _separate_ `arm64` artifacts for Brimcap like we've done for Zed and Zui. However, in the interest of getting our next releases out in a timely manner, I'd prefer to make that a separate/future exercise.

I tested out these changes in a personal fork repo where you can see test release [v1.7.1](https://github.com/philrz/brimcap/releases/tag/v1.7.1) that shows the problem and [v1.8.1](https://github.com/philrz/brimcap/releases/tag/v1.8.1) that has the benefit of the fix.