### PR TITLE
Update CHANGELOG.md for v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.17.0
+* Because Brimcap is dependent on the [Zed project](https://zed.brimdata.io/), GA Brimcap release major/minor version numbers are now synchronized to the corresponding [Zed release](https://github.com/brimdata/zed/releases)
+* Advance Zed dependency to include recent fixes/enhancements
+
 ## v1.8.0
 * Advance Zed dependency to include recent fixes/enhancements
 * Update bundled Zeek to [v6.2.0-brim2](https://github.com/brimdata/build-zeek/releases/tag/v6.2.0-brim2) (#342)


### PR DESCRIPTION
## What's Changing

These are the customary CHANGELOG updates as part of a new set of GA releases, now with the release tag matching the dependent Zed release.

## Why

As previously mentioned in a team sync, having matching release tags helps in at least two ways:

1. It makes it easier for us to write content about new releases (i.e., no need to mention the separate version numbers for Zui, Brimcap, and Zed in our announcements on social media or the blog)
2. It makes it easier for users to feel confident that the Zed-dependent software like Zui/Brimcap are compatible with their Zed lakes/programsAPI/etc. by checking version strings and seeing they match.

## Discussion

I explicitly called out "major/minor version numbers" in the CHANGELOG to leave wiggle room for the possibility that we might do quick patch releases on any given project to fix bugs without releasing new patch versions of everything else. If folks think that's  a "duh!" thing not worth calling out and I'm just wasting words I'm happy to shorten.