### PR TITLE
Point to Zeek v7.0.0-brim1 artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -s -X github.com/brimdata/brimcap/cli.Version=$(VERSION)
 
 SURICATATAG = v5.0.3-brim5
 SURICATAPATH = suricata-$(SURICATATAG)
-ZEEKTAG = v6.2.0-brim2
+ZEEKTAG = v7.0.0-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
 ZIP = zip -r


### PR DESCRIPTION
This moves Brimcap (and hence will next move Zui) to the [Zeek v7.0.0-brim1 artifact](https://github.com/brimdata/build-zeek/releases/tag/v7.0.0-brim1).