### PR TITLE
upgrade Zed to 427a57b70a954f990857c5190c44713b22d04ac8

### DIFF
--- a/cli/pcapsearchflags.go
+++ b/cli/pcapsearchflags.go
@@ -34,9 +34,7 @@ func (f *PcapSearchFlags) SetFlags(fs *flag.FlagSet) {
 			f.duration = 1
 			return nil
 		}
-		arena := zed.NewArena()
-		defer arena.Unref()
-		val, err := zson.ParseValue(zed.NewContext(), arena, s)
+		val, err := zson.ParseValue(zed.NewContext(), s)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/brimdata/brimcap
 go 1.21
 
 require (
-	github.com/brimdata/zed v1.17.1-0.20240913153822-4290afdca76d
+	github.com/brimdata/zed v1.17.1-0.20240916171320-427a57b70a95
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gopacket/gopacket v1.2.0
 	github.com/gosuri/uilive v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f h1:y06x6vGnFYf
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/brimdata/zed v1.17.1-0.20240913153822-4290afdca76d h1:AB7RmPV+mRmfWDK5F5oxvBbvrdJ/8N0KRTBxmGTr8wA=
-github.com/brimdata/zed v1.17.1-0.20240913153822-4290afdca76d/go.mod h1:DsN4jhoF1EvqHhzMTSz1GJGltBMh2iQeV1/GVEeeso0=
+github.com/brimdata/zed v1.17.1-0.20240916171320-427a57b70a95 h1:/T2gNKxt8boZg2vvm/NfNEE8BTMud4kg1JGaS649LZo=
+github.com/brimdata/zed v1.17.1-0.20240916171320-427a57b70a95/go.mod h1:DsN4jhoF1EvqHhzMTSz1GJGltBMh2iQeV1/GVEeeso0=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/ztail/ztail.go
+++ b/ztail/ztail.go
@@ -20,7 +20,6 @@ import (
 // written log data are transformed into *zed.Values and returned on a
 // first-come-first serve basis.
 type Tailer struct {
-	arena      *zed.Arena // Owns the zed.Value returned by Read
 	forceClose uint32
 	opts       anyio.ReaderOpts
 	readers    map[string]*tail.File
@@ -60,9 +59,8 @@ type nopWarner struct{}
 func (nopWarner) Warn(_ string) error { return nil }
 
 type result struct {
-	zv    *zed.Value
-	arena *zed.Arena
-	err   error
+	zv  *zed.Value
+	err error
 }
 
 func (t *Tailer) start() {
@@ -152,10 +150,9 @@ func (t *Tailer) tailFile(file string) error {
 			if val == nil {
 				return
 			}
-			arena := zed.NewArena()
 			// Copy because we may read the next value before
 			// Tailer.Read's caller has finished with this one.
-			t.results <- result{val.Copy(arena).Ptr(), arena, nil}
+			t.results <- result{zv: val.Copy().Ptr()}
 		}
 	}()
 	return nil
@@ -173,10 +170,6 @@ func (t *Tailer) Read() (*zed.Value, error) {
 		for range t.results {
 		}
 	}
-	if t.arena != nil {
-		t.arena.Unref()
-	}
-	t.arena = res.arena
 	return res.zv, res.err
 }
 


### PR DESCRIPTION
Go changes revert fc1c6e6f3da9cfda9a02e662f1b0554c0f8f267d to accomodate brimdata/zed#5278.