### PR TITLE
Update 5-tuple link in Troubleshooting doc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-20.04, windows-2022]
+        os: [macos-14, ubuntu-24.04, windows-2022]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -27,7 +27,7 @@ detail.
 ### Application problems
 
 To start debugging such problems, it helps to understand how Zui opens flows
-extracted from pcaps. Once the [5-tuple](https://www.napatech.com/what-is-a-flow/), connection start time, and connection
+extracted from pcaps. Once the [5-tuple](https://nordvpn.com/cybersecurity/glossary/5-tuple/), connection start time, and connection
 duration are isolated from the Zeek `conn` record for the flow, Zui
 invokes `brimcap search` to extract the packets for the target flow
 into a temporary file. Once this temporary file has been written to the local
@@ -86,7 +86,7 @@ Stream_ or _Follow UDP Stream_, which will apply a filter of the format
 `tcp.stream eq N` or `udp.stream eq N`, where `N` is a number `0`, `1`, etc.
 based on which flow within the pcap is being isolated. When this is done,
 Wireshark appears to treat all packets as part of the same flow if they
-share the same [5-tuple](https://www.napatech.com/what-is-a-flow/),
+share the same [5-tuple](https://nordvpn.com/cybersecurity/glossary/5-tuple/),
 regardless of how long the flow lasts.
 
 To similarly attempt to isolate flows, Zui relies on Zeek's `conn` event,


### PR DESCRIPTION
The link we'd been using previously has been giving HTTP 403 errors in the nightly link checker for a couple days now. Maybe that's a temporary problem, but on the assumption they just don't like being crawled or something we can use a different one.